### PR TITLE
Keep v1 legacy texts

### DIFF
--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/config/WSBaseConfig.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/config/WSBaseConfig.java
@@ -143,8 +143,7 @@ public abstract class WSBaseConfig implements SchedulingConfigurer, WebMvcConfig
     public MessageSource messageSource() {
         ReloadableResourceBundleMessageSource messageSource =
                 new ReloadableResourceBundleMessageSource();
-
-        messageSource.setBasename("classpath:i18n/messages");
+        messageSource.setBasenames("classpath:i18n/messages", "classpath:i18n/messages_v1_legacy");
         messageSource.setDefaultEncoding("UTF-8");
         messageSource.setFallbackToSystemLocale(false);
         messageSource.setDefaultLocale(null);

--- a/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/GaenConfigController.java
+++ b/dpppt-config-backend/src/main/java/org/dpppt/switzerland/backend/sdk/config/ws/controller/GaenConfigController.java
@@ -122,11 +122,12 @@ public class GaenConfigController {
 			@Documentation(description = "Version of the App installed", example = "ios-1.0.7") @RequestParam String appversion,
 			@Documentation(description = "Version of the OS", example = "ios13.6") @RequestParam String osversion,
 			@Documentation(description = "Build number of the app", example = "ios-200619.2333.175") @RequestParam String buildnr) {
+		Version userAppVersion = new Version(appversion);
 		ConfigResponse config = new ConfigResponse();
 		config.setCheckInUpdateNotificationEnabled(this.checkInUpdateNotificationEnabled);
 		config.setInterOpsCountries(interOpsCountryCodes);
 		config.setTestInformationUrls(testLocationHelper.getTestInfoUrls());
-		config.setWhatToDoPositiveTestTexts(whatToDoPositiveTestTexts(messages));
+		config.setWhatToDoPositiveTestTexts(whatToDoPositiveTestTexts(userAppVersion, messages));
 		config.setTestLocations(testLocationHelper.getTestLocations());
 
 		// For iOS 13.6 users show information about weekly notification
@@ -147,7 +148,6 @@ public class GaenConfigController {
 		}
 
 		// Check for old app Versions, iOS only
-		Version userAppVersion = new Version(appversion);
 		if (userAppVersion.isIOS() && APP_VERSION_1_0_9.isLargerVersionThan(userAppVersion)) {
 			config = generalUpdateRelease(true);
 		}
@@ -419,54 +419,61 @@ public class GaenConfigController {
 		}
 	}
 
-	private WhatToDoPositiveTestTextsCollection whatToDoPositiveTestTexts(Messages messages) {
+	private WhatToDoPositiveTestTextsCollection whatToDoPositiveTestTexts(Version appVersion, Messages messages) {
+		final String prefix;
+		if (appVersion.isSmallerVersionThan(new Version("2.0.0"))) {
+			prefix = "v1_legacy_";
+		} else {
+			prefix = "";
+		}
+
 		return new WhatToDoPositiveTestTextsCollection() {
 			{
-				setDe(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("de")));
-				setFr(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("fr")));
-				setIt(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("it")));
-				setEn(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("en")));
-				setPt(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("pt")));
-				setEs(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("es")));
-				setSq(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("sq")));
-				setBs(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("bs")));
-				setHr(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("hr")));
-				setSr(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("sr")));
-				setRm(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("rm")));
-				setTr(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("tr")));
-				setTi(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("ti")));
+				setDe(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("de"), prefix));
+				setFr(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("fr"), prefix));
+				setIt(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("it"), prefix));
+				setEn(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("en"), prefix));
+				setPt(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("pt"), prefix));
+				setEs(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("es"), prefix));
+				setSq(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("sq"), prefix));
+				setBs(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("bs"), prefix));
+				setHr(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("hr"), prefix));
+				setSr(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("sr"), prefix));
+				setRm(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("rm"), prefix));
+				setTr(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("tr"), prefix));
+				setTi(getWhatToDoPositiveTestText(messages, Locale.forLanguageTag("ti"), prefix));
 			}
 		};
 	}
 
-	private WhatToDoPositiveTestTexts getWhatToDoPositiveTestText(Messages messages, Locale locale) {
+	private WhatToDoPositiveTestTexts getWhatToDoPositiveTestText(Messages messages, Locale locale, String prefix) {
 		return new WhatToDoPositiveTestTexts() {
 			{
-				setEnterCovidcodeBoxSupertitle(messages.getMessage("inform_detail_box_subtitle", locale));
-				setEnterCovidcodeBoxTitle(messages.getMessage("inform_detail_box_title", locale));
-				setEnterCovidcodeBoxText(messages.getMessage("inform_detail_box_text", locale));
-				setEnterCovidcodeBoxButtonTitle(messages.getMessage("inform_detail_box_button", locale));
+				setEnterCovidcodeBoxSupertitle(messages.getMessage(prefix + "inform_detail_box_subtitle", locale));
+				setEnterCovidcodeBoxTitle(messages.getMessage(prefix + "inform_detail_box_title", locale));
+				setEnterCovidcodeBoxText(messages.getMessage(prefix + "inform_detail_box_text", locale));
+				setEnterCovidcodeBoxButtonTitle(messages.getMessage(prefix + "inform_detail_box_button", locale));
 
-				setInfoBox(getWhatToDoPositiveTestTextInfoBox(messages, locale));
+				setInfoBox(getWhatToDoPositiveTestTextInfoBox(messages, locale, prefix));
 
 				setFaqEntries(Arrays.asList(new FaqEntry() {
 					{
-						setTitle(messages.getMessage("inform_detail_faq1_title", locale));
-						setText(messages.getMessage("inform_detail_faq1_text", locale));
+						setTitle(messages.getMessage(prefix + "inform_detail_faq1_title", locale));
+						setText(messages.getMessage(prefix + "inform_detail_faq1_text", locale));
 						setIconAndroid("ic_verified_user");
 						setIconIos("ic-verified-user");
 					}
 				}, new FaqEntry() {
 					{
-						setTitle(messages.getMessage("inform_detail_faq2_title", locale));
-						setText(messages.getMessage("inform_detail_faq2_text", locale));
+						setTitle(messages.getMessage(prefix + "inform_detail_faq2_title", locale));
+						setText(messages.getMessage(prefix + "inform_detail_faq2_text", locale));
 						setIconAndroid("ic_key");
 						setIconIos("ic-key");
 					}
 				}, new FaqEntry() {
 					{
-						setTitle(messages.getMessage("inform_detail_faq3_title", locale));
-						setText(messages.getMessage("inform_detail_faq3_text", locale));
+						setTitle(messages.getMessage(prefix + "inform_detail_faq3_title", locale));
+						setText(messages.getMessage(prefix + "inform_detail_faq3_text", locale));
 						setIconAndroid("ic_person");
 						setIconIos("ic-user");
 					}
@@ -475,15 +482,15 @@ public class GaenConfigController {
 		};
 	}
 	
-    private InfoBox getWhatToDoPositiveTestTextInfoBox(Messages messages, Locale locale) {
+    private InfoBox getWhatToDoPositiveTestTextInfoBox(Messages messages, Locale locale, String prefix) {
         InfoBox infoBox = new InfoBox();
         infoBox.setTitle(
-                messages.getMessage("inform_detail_infobox1_title", locale));
-        infoBox.setMsg(messages.getMessage("inform_detail_infobox1_text", locale));
-        infoBox.setUrlTitle(messages.getMessage("infoline_coronavirus_number", locale));
-        infoBox.setUrl("tel:" + messages.getMessage("infoline_coronavirus_number", locale).replace(" ", ""));
+                messages.getMessage(prefix + "inform_detail_infobox1_title", locale));
+        infoBox.setMsg(messages.getMessage(prefix + "inform_detail_infobox1_text", locale));
+        infoBox.setUrlTitle(messages.getMessage(prefix + "infoline_coronavirus_number", locale));
+        infoBox.setUrl("tel:" + messages.getMessage(prefix + "infoline_coronavirus_number", locale).replace(" ", ""));
         infoBox.setIsDismissible(false);
-		infoBox.setHearingImpairedInfo(messages.getMessage("hearing_impaired_info", locale)); 
+		infoBox.setHearingImpairedInfo(messages.getMessage(prefix + "hearing_impaired_info", locale));
         return infoBox;
     }
 }

--- a/dpppt-config-backend/src/main/resources/i18n/messages_bs.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_bs.properties
@@ -327,8 +327,8 @@ bs:
     share_app_supertitle: Zajedno…
     share_app_title: Sprečimo širenje infekcije
     share_app_button: Deli aplikaciju
-    share_app_body: Ako što više nas aktivira aplikaciju SwissCovid, moći ćemo pravovremeno da prekinemo lanac širenja infekcije.
-    share_app_message: Ako što više nas aktivira aplikaciju SwissCovid, moći ćemo pravovremeno da prekinemo lanac širenja infekcije.
+    share_app_body: Ako većina vaših kontakata koristi aplikaciju SwissCovid, možete brzo biti obavešteni u slučaju rizika od zaraze.
+    share_app_message: Pomoću aplikacije Swiss Covid svi možemo da pomognemo u suzbijanju širenja virusa korona.
     share_app_url: https://bag-coronavirus.ch/swisscovid-app/#download
     stats_counter: {COUNT} milion
     stats_source_day: Stanje na dan {DAY}
@@ -478,7 +478,7 @@ bs:
     inform_send_thankyou_text_onsetdate: {ONSET_DATE} – danas
     inform_send_thankyou_text_stop_infection_chains: Na taj način pomažete da se upozore drugi o mogućosti zaraze.
     inform_send_thankyou_text_onsetdate_info: Privatni ključevi vaše aplikacije poslati su za sledeći period:
-    android_inform_tracing_enabled_explanation: Prilikom unosa kovid šifre mora se aktivirati praćenje (tracing) kako bi vaši privatni ključevi mogli da se dele.
+    inform_tracing_enabled_explanation: Prilikom unosa kovid šifre mora se aktivirati praćenje (tracing) kako bi vaši privatni ključevi mogli da se dele.
     leitfaden_infopopup_text: Kada pritisnete "{BUTTON_TITLE}" napuštate aplikaciju i dolazite na internet stranicu SwissCovid vodiča. Pri tome se podaci poslednjeg susreta sa mogućim zaražavanjem šalju internet stranici.
     leitfaden_infopopup_title: Informacije iz SwissCovid vodiča
     germany_update_boarding_title: Kompatibilno sa Nemačkom
@@ -501,10 +501,10 @@ bs:
     edit_mode_comment_placeholder: npr. S kim ste bili tamo?
     done_button: Gotovo
     checkin_set_reminder: Podsećanje na prijavu
-    reminder_option_off: Isključeno
+    reminder_option_off: Off
     authenticate_for_diary: Identifikujte se, kako biste pristupili dnevniku
-    reminder_option_hours: časovi {HOURS} h
-    reminder_option_minutes: minute {MINUTES}'
+    reminder_option_hours: {HOURS} h
+    reminder_option_minutes: {MINUTES}'
     qr_scanner_no_camera_permission: Aplikaciji je potreban pristup kameri, da bi se skenirao QR kod.
     diary_title: Moje prijave
     checkin_button_title: Prijava
@@ -515,7 +515,7 @@ bs:
     module_checkins_title: Prijava
     checkin_title: Prijava
     checkins_create_qr_code: Napraviti QR kod
-    events_title: Ponuditi prijave?
+    events_title: Napravite QR kodove
     check_in_now_button_title: Sada se prijaviti
     checkin_reminder_settings_alert_title: Podsećanje nije uspelo da se unese
     checkin_reminder_settings_alert_message: Da biste dobijali podsetnike za odjavu, morate da dozvolite \ "Obaveštenja \" u podešavanjima aplikacije.
@@ -552,7 +552,7 @@ bs:
     checkin_ended_title: Deaktivirano prijavljivanje
     checkin_ended_text: Trenutno nije moguća prijava
     checkin_detail_checked_out_text: Skenirajte SwissCovid-QR kod, kako biste se prijavili na nekoj lokaciji.
-    checkin_detail_diary_text: Ako skenirate Swiss-Covid-QR kod, da biste se prijavili na nekoj lokaciji, ovde se automatski uređuje unos.
+    checkin_detail_diary_text: Ako skenirate SwissCovid-QR kod, da biste se prijavili na nekoj lokaciji, ovde se automatski uređuje unos.
     checkin_checked_in: Prijavljeni ste
     checkout_from_to_date: {DATE1} do {DATE2}
     inform_detail_covidcode_info_button: Više o Covid kodu
@@ -563,7 +563,7 @@ bs:
     module_checkins_description: Skenirajte SwissCovid-QR kod, kako biste se prijavili na nekoj lokaciji.
     inform_share_checkins_title: Deliti unose o prijavama
     inform_share_checkins_subtitle: Kada delite unose prijave, aplikacija može istovremeno da obavesti lica, koja su se prijavila na istoj lokaciji.
-    inform_share_checkins_select_all: Izabrati sve
+    inform_share_checkins_select_all: Izaberite sve što odgovara
     inform_dont_send_button_title: Ne slati
     inform_dont_share_button_title: Ne deliti
     inform_really_not_share_title: Zaista ne deliti?
@@ -574,10 +574,10 @@ bs:
     remove_diary_warning_hide_title: Samo sakriti i nastaviti da budete obaveštavani?
     home_covidcode_card_title: Test pozitivan?
     home_end_isolation_card_text: Kontakte i prijave ponovo aktivirati. 
-    reminder_option_hours_minutes: časovi {HOURS} h minute {MINUTES}'
+    reminder_option_hours_minutes: {HOURS} h {MINUTES}'
     checkin_overview_isolation_text: Ne možete ponovo da se prijavite ako imate pozitivan test.
     events_card_subtitle: Napravite QR kod, pomoću kojeg lica mogu da se prijave na lokaciji.
-    delete_qr_code_dialog: Želite li zaista da izbrišete QR kod? 
+    delete_qr_code_dialog: Želite li zaista da izbrišete QR kod? Štampani QR kodovi ostaju i dalje na snazi.
     self_checkin_button_title: Samostalno prijavljivanje
     checkin_overview_checkins_explanation: Skenirajte SwissCovid-QR kod, kako biste se prijavili na lokaciji.
     checkout_overlapping_alert_title: Nije moguće obezbeđenje
@@ -591,7 +591,7 @@ bs:
     checkin_detail_checked_out_title: Prijaviti se bez ostavljanja podataka
     home_covidcode_card_text: Ovde unesite svoj Covid kod, kako biste upozorili druge.
     home_end_isolation_card_title: Kraj izolacije?
-    events_card_title: Želite da ponudite prijave?
+    events_card_title: Da li želite da napravite QR kodove?
     checkin_footer_title1: Čemu služi funkcija prijave?
     checkin_footer_subtitle1: Funkcija prijave bez unošenja podataka o kontaktima povećava funkcije aplikacije SwissCovid. Pomoću ove funkcije, u slučaju pozitivnog testa, možete ne samo da upozorite bliske kontakte, već i lica koja su se istovremeno prijavila na istom mestu.
     checkin_footer_title2: Nema centralnog čuvanja podataka
@@ -620,7 +620,7 @@ bs:
     checkin_report_title3: Vršiti testiranje
     checkin_report_subtitle1: Mogli biste biti zarazni, a da to ne primetite. Pridržavajte se važećih higijenskih i zaštitnih mera i zaštitite svoju porodicu, prijatelje i okolinu.
     checkin_report_subtitle2: Proveravajte svoje zdravsveno stanje.
-    checkin_report_subtitle3: Odmah se testirajte ako imate simptome. Čak i ako nema simptoma, test korone je važan i  preporučuje se.
+    checkin_report_subtitle3: Odmah se testirajte ako imate simptome. Čak i ako nema simptoma i niste u potpunosti vakcinisani, test korone je važan i  preporučuje se.
     meldung_detail_checkin_title: Prijava
     not_thank_you_screen_title: Podaci nisu poslati
     not_thank_you_screen_text1: Nisu poslati privatni ključevi.
@@ -649,3 +649,19 @@ bs:
     partial_onboarding_done_text: Hvala vam što pomažete u suzbijanju širenja virusa korone.
     web_slogan: Brze informacije u slučaju rizika od zaraze. 
     test_info_url: https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/testen.html
+    checkout_too_long_alert_text: Ova prijava važi maksimalno u trajanju od {DURATION}. Molimo vas da ponovo proverite svoje podatke.
+    accessibility_camera_light_on: Uključiti svetlo
+    accessibility_camera_light_off: Isključiti svetlo
+    error_cannot_enter_covidcode_while_checked_in: Još uvek ste prijavljeni. Molimo odjavite se pre unosa Covid koda.
+    events_card_title_events_not_empty: Moji QR kodovi
+    checkout_inverse_time_alert_description: Odabrano vreme za odjavu nalazi se je pre vremena za prijavu. Molimo vas da ponovo proverite svoje podatke.
+    update_notification_checkin_feature_title: Nova funkcija: prijava
+    update_notification_checkin_feature_text: Hvala vam što koristite SwissCovid. Sa najnovijom verzijom aplikacije možete da se prijavite na lokaciji bez ostavljanja podataka.
+    diary_current_title: Trenutno
+    ios_snooze_option_30min: Podsetiti ponovo (30min)
+    ios_snooze_option_1h: Podsetiti ponovo (1h)
+    ios_snooze_option_2h: Podsetiti ponovo (2h)
+    ios_notification_checkout_now: Sada se odjaviti
+    covid_certificate_alert_text: Molimo koristite aplikaciju "COVID certifikat" za skeniranje ovog QR koda.
+    covid_certificate_open_app: Otvoriti aplikaciju
+    covid_certificate_install_app: Instalirati aplikaciju

--- a/dpppt-config-backend/src/main/resources/i18n/messages_de.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_de.properties
@@ -311,7 +311,7 @@ de:
     travel_title: Reisen
     travel_home_description: SwissCovid-Begegnungen funktioniert in den folgenden Ländern:
     travel_screen_explanation_title_1: Was bedeutet das?
-    travel_screen_explanation_text_1: Wenn Sie in einem der kompatiblen Länder unterwegs sind, müssen Sie keine andere Corona-App installieren.\n\nSwissCovid überprüft die in den kompatiblen Ländern veröffentlichten privaten Schlüssel. So können Sie auch bei einer möglichen Ansteckung im Ausland gewarnt werden.
+    travel_screen_explanation_text_1: Wenn Sie in einem der kompatiblen Länder unterwegs sind, müssen Sie für Begegnungen keine andere Corona-App installieren.\n\nSwissCovid überprüft die in den kompatiblen Ländern veröffentlichten privaten Schlüssel. So können Sie auch bei einer möglichen Ansteckung im Ausland gewarnt werden.
     travel_screen_explanation_title_2: Was geschieht bei Eingabe des Covidcodes?
     travel_screen_explanation_text_2: Bei der Eingabe des Covidcodes werden die von Ihnen gesendeten privaten Schlüssel auch mit den kompatiblen Ländern geteilt.\n\nDamit auch Reisende aus dem Ausland gewarnt werden können, geschieht das unabhängig davon, ob Sie selber im Ausland unterwegs waren oder nicht.
     accessibility_faq_button_hint_non_bag: Dieser Button verlässt die App und öffnet eine Website.
@@ -328,8 +328,8 @@ de:
     share_app_supertitle: Gemeinsam…
     share_app_title: Ansteckungen verhindern
     share_app_button: App teilen
-    share_app_body: Wenn möglichst viele die SwissCovid App nutzen, können wir Infektionsketten frühzeitig unterbrechen.
-    share_app_message: Wenn möglichst viele die SwissCovid App nutzen, können wir Infektionsketten frühzeitig unterbrechen.
+    share_app_body: Wenn möglichst viele Ihrer Kontakte die SwissCovid App nutzen, können Sie bei einem Ansteckungsrisiko schnell informiert werden.
+    share_app_message: Mit der SwissCovid App können alle dazu beitragen, die Verbreitung des Coronavirus einzudämmen.
     share_app_url: https://bag-coronavirus.ch/swisscovid-app/#download
     stats_counter: {COUNT} Mio.
     stats_source_day: Stand der Daten {DAY}
@@ -469,7 +469,7 @@ de:
     homescreen_isolation_ended_popup_text: Das Tracing kann wieder aktiviert werden, sobald Sie die Isolation beendet haben.
     answer_yes: Ja
     answer_no: Nein
-    travel_screen_info: Unterwegs im Ausland? In diesen Ländern funktioniert SwissCovid.
+    travel_screen_info: Unterwegs im Ausland? In diesen Ländern funktioniert SwissCovid-Begegnungen.
     travel_screen_compatible_countries: Kompatible Länder:
     inform_code_travel_text: Damit auch Reisende aus dem Ausland nach einer Begegnung gewarnt werden können, werden die privaten Schlüssel mit den Corona-Apps der kompatiblen Länder geteilt.
     stats_covidcodes_total_header: Total
@@ -480,7 +480,7 @@ de:
     inform_send_thankyou_text_onsetdate: {ONSET_DATE} – heute
     inform_send_thankyou_text_stop_infection_chains: Auf diese Weise helfen Sie, andere vor einer möglichen Ansteckung zu warnen.
     inform_send_thankyou_text_onsetdate_info: Die privaten Schlüssel Ihrer App wurden für den folgenden Zeitraum gesendet:
-    android_inform_tracing_enabled_explanation: Beim Eingeben eines Covidcodes muss das Tracing aktiviert sein, damit Ihre privaten Schlüssel geteilt werden können.
+    inform_tracing_enabled_explanation: Bitte Tracing aktivieren, um automatisch erkannte Begegnungen zu teilen und andere zu warnen.
     leitfaden_infopopup_text: Wenn Sie "{BUTTON_TITLE}" drücken, verlassen Sie die App und wechseln auf die Website des SwissCovid Leitfadens. Dabei werden die Daten der letzten Begegnungen von möglichen Ansteckungen der Website mitgeschickt.
     leitfaden_infopopup_title: Information SwissCovid Leitfaden
     germany_update_boarding_title: Kompatibel mit Deutschland
@@ -517,7 +517,7 @@ de:
     module_checkins_title: Check-in
     checkin_title: Check-In
     checkins_create_qr_code: QR-Code erstellen
-    events_title: Check-ins anbieten?
+    events_title: QR-Codes erstellen
     check_in_now_button_title: Jetzt einchecken
     checkin_reminder_settings_alert_title: Die Erinnerung konnte nicht gesetzt werden
     checkin_reminder_settings_alert_message: Damit Sie Check-out Erinnerungen erhalten, müssen Sie \"Mitteilungen\" in den App-Einstellungen erlauben.
@@ -554,7 +554,7 @@ de:
     checkin_ended_title: Check-In deaktiviert
     checkin_ended_text: Derzeit ist kein Check-in möglich
     checkin_detail_checked_out_text: Scannen Sie einen SwissCovid-QR-Code, um sich vor Ort einzuchecken.
-    checkin_detail_diary_text: Wenn Sie einen Swiss-Covid-QR-Code scannen, um sich vor Ort einzuchecken, wird hier automatisch ein Eintrag angelegt.
+    checkin_detail_diary_text: Wenn Sie einen SwissCovid-QR-Code scannen, um sich vor Ort einzuchecken, wird hier automatisch ein Eintrag angelegt.
     checkin_checked_in: Sie sind eingecheckt
     checkout_from_to_date: {DATE1} bis {DATE2}
     inform_detail_covidcode_info_button: Mehr zum Covidcode
@@ -565,7 +565,7 @@ de:
     module_checkins_description: Scannen Sie einen SwissCovid-QR-Code, um sich vor Ort einzuchecken.
     inform_share_checkins_title: Check-in-Einträge teilen
     inform_share_checkins_subtitle: Wenn Sie Ihre Check-in-Einträge teilen, kann die App Personen benachrichtigen, die zum gleichen Zeitpunkt am gleichen Ort eingecheckt haben.
-    inform_share_checkins_select_all: Alle auswählen
+    inform_share_checkins_select_all: Alle passenden auswählen
     inform_dont_send_button_title: Nicht senden
     inform_dont_share_button_title: Nicht teilen
     inform_really_not_share_title: Wirklich nicht teilen?
@@ -578,8 +578,8 @@ de:
     home_end_isolation_card_text: Begegnungen und Check-in wieder aktivieren.
     reminder_option_hours_minutes: {HOURS} h {MINUTES}'
     checkin_overview_isolation_text: Sie können nicht mehr einchecken, wenn Sie positiv getestet wurden.
-    events_card_subtitle: Erstellen Sie einen QR-Code, mit dem sich Personen vor Ort einchecken können.
-    delete_qr_code_dialog: Möchten Sie den QR Code wirklich löschen?
+    events_card_subtitle: Erstellen Sie einen SwissCovid-QR-Code, mit dem sich Personen vor Ort einchecken können.
+    delete_qr_code_dialog: Möchten Sie den QR Code wirklich löschen? Gedruckte QR-Codes bleiben weiterhin gültig.
     self_checkin_button_title: Self Check-In
     checkin_overview_checkins_explanation: Scannen Sie einen SwissCovid-QR-Code, um sich vor Ort einzuchecken.
     checkout_overlapping_alert_title: Sichern nicht möglich
@@ -593,7 +593,7 @@ de:
     checkin_detail_checked_out_title: Einchecken ohne Daten \nzu hinterlassen
     home_covidcode_card_text: Geben Sie hier Ihren Covidcode ein, um andere zu warnen.
     home_end_isolation_card_title: Isolation beenden?
-    events_card_title: Sie möchten Check-ins anbieten?
+    events_card_title: Sie möchten QR-Codes erstellen?
     checkin_footer_title1: Warum eine Check-in-Funktion?
     checkin_footer_subtitle1: Die Check-in-Funktion ohne Erfassung der Kontaktdaten erweitert die SwissCovid App. Mit dieser Funktion können Sie im Falle eines positiven Tests nicht nur enge Kontakte, sondern auch Personen, die zum gleichen Zeitpunkt am gleichen Ort eingecheckt haben, warnen.
     checkin_footer_title2: Keine zentrale Datenspeicherung
@@ -622,7 +622,7 @@ de:
     checkin_report_title3: Testen lassen
     checkin_report_subtitle1: Sie könnten bereits ansteckend sein, ohne es zu merken. Beachten Sie die geltenden Hygiene- und Schutzmassnahmen und schützen Sie Ihre Familie, Ihre Freunde und Ihr Umfeld.
     checkin_report_subtitle2: Überwachen Sie Ihren Gesundheitszustand.
-    checkin_report_subtitle3: Lassen Sie sich beim Auftreten von Symptomen sofort testen. Auch wenn keine Symptome auftreten, ist ein Corona-Test sinnvoll und empfohlen.
+    checkin_report_subtitle3: Lassen Sie sich beim Auftreten von Symptomen sofort testen. Wenn keine Symptome auftreten und Sie noch nicht vollständig geimpft sind, ist ein Corona-Test ebenfalls sinnvoll und empfohlen.
     meldung_detail_checkin_title: Check-In
     not_thank_you_screen_title: Keine Daten gesendet
     not_thank_you_screen_text1: Es wurden keine privaten Schlüssel gesendet.
@@ -652,3 +652,18 @@ de:
     web_slogan: Bei einem Ansteckungsrisiko schnell informiert.
     test_info_url: https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/testen.html
     checkout_too_long_alert_text: Für diesen Check-In gilt eine maximale Check-in Dauer von {DURATION}. Bitte überprüfen Sie nochmals Ihre Angabe.
+    accessibility_camera_light_on: Licht an
+    accessibility_camera_light_off: Licht aus
+    error_cannot_enter_covidcode_while_checked_in: Sie sind noch eingecheckt. Bitte checken Sie aus bevor Sie den Covidcode eingeben.
+    events_card_title_events_not_empty: Meine QR-Codes
+    checkout_inverse_time_alert_description: Ihre gewählte Checkout-Zeit liegt vor der Check-In-Zeit. Bitte überprüfen Sie nochmals Ihre Angabe.
+    update_notification_checkin_feature_title: Neue Funktion: Check-in
+    update_notification_checkin_feature_text: Danke für die Nutzung von SwissCovid. Mit der neusten App-Version können Sie sich vor Ort einchecken, ohne Daten zu hinterlassen.
+    diary_current_title: Aktuell
+    ios_snooze_option_30min: Nochmals erinnern (30min)
+    ios_snooze_option_1h: Nochmals erinnern (1h)
+    ios_snooze_option_2h: Nochmals erinnern (2h)
+    ios_notification_checkout_now: Jetzt auschecken
+    covid_certificate_alert_text: Bitte benutzen Sie zum Scannen dieses QR-Codes die App "COVID Certificate".
+    covid_certificate_open_app: App öffnen
+    covid_certificate_install_app: App installieren

--- a/dpppt-config-backend/src/main/resources/i18n/messages_en.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_en.properties
@@ -71,7 +71,7 @@ en:
     symptom_detail_box_title: Getting tested
     symptom_detail_box_button: Further information
     symptom_detail_box_text: The FOPH recommends that anyone with COVID-19 symptoms should get tested. Call your doctor or your healthcare facility to schedule an appointment.
-    inform_detail_navigation_title: Tested positive
+    inform_detail_navigation_title: Positive test
     symptom_detail_navigation_title: Symptoms
     tracing_turned_off_title: Proximity tracing deactivated
     tracing_turned_off_text: Activate proximity tracing so that the app works.
@@ -85,11 +85,11 @@ en:
     no_meldungen_box_title: Protect yourself
     no_meldungen_box_subtitle: What should I do?
     no_meldungen_box_text: Follow the government recommendations on hygiene and social distancing.
-    meldung_detail_positive_tested_title: Tested positive
+    meldung_detail_positive_tested_title: Positive test
     meldung_detail_positive_tested_subtitle: You have tested positive for the coronavirus.
     meldung_detail_positive_test_box_subtitle: What should I do?
     meldung_detail_positive_test_box_title: Isolation
-    meldung_detail_positive_test_box_text: Follow the instructions you receive on isolation.
+    meldung_detail_positive_test_box_text: Follow the instructions you received on isolation.
     tracing_ended_title: Encounters and check-in deactivated
     tracing_ended_text: No encounters registered
     exposed_info_contact_hotline: Contact the
@@ -97,7 +97,7 @@ en:
     meldung_homescreen_positive_info_line2: Instructions on self-isolation
     meldung_detail_exposed_new_meldung: New report
     meldung_detail_exposed_title: Potential infection
-    meldung_homescreen_positiv_title: Tested positive
+    meldung_homescreen_positiv_title: Positive test
     meldung_detail_exposed_subtitle: You may have been infected
     meldung_homescreen_positiv_text: You have tested positive for the coronavirus.
     reset_onboarding: Reset onboarding
@@ -142,8 +142,8 @@ en:
     onboarding_push_button: Enable messages
     onboarding_push_gtk_title1: Notified immediately
     onboarding_push_gtk_text1: In the event of a potential infection, you will receive a message on the lock screen.
-    inform_send_getwell_title: Get well soon!
-    inform_send_getwell_text: Get well soon! \n\nFollow the instructions  you have received on isolation.
+    inform_send_getwell_title: Take care and...
+    inform_send_getwell_text: get well soon! \n\nFollow the instructions you have received on isolation.
     onboarding_go_title: The app is ready to go
     onboarding_go_text: Thank you for helping to stop the spread of coronavirus.
     onboarding_go_button: Start
@@ -214,7 +214,7 @@ en:
     faq_button_url: https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/faq-kontakte-downloads/haeufig-gestellte-fragen.html?faq-url=/en/categories/swisscovid-app
     inform_code_intro_title: Information on the entry
     inform_code_intro_text: Although no personal data relating to you is sent out, it may well be that someone remembers their encounter with you from the date.
-    inform_code_intro_button: Agree
+    inform_code_intro_button: Agreed
     symptom_faq1_title: What are the symptoms of COVID-19?
     symptom_faq1_text: These are the most common symptoms of COVID-19:\n\n– Fever, feverish feeling \n– Sore throat\n– Cough (mostly dry)\n– Shortness of breath\n– Body aches\n– Sudden loss of the sense of taste and/or smell\n\nOther symptoms may include:\n\n– Headache\n– General weakness, feeling unwell\n– Aching muscles\n– Head cold\n– Gastrointestinal symptoms (nausea, vomiting, diarrhoea, stomach ache)\n– Skin rash
     meldungen_positive_tested_faq1_title: Why is tracing deactivated?
@@ -277,7 +277,7 @@ en:
     tracing_active_tracking_always_info: SwissCovid remains active even if the app has been closed.
     oboarding_splashscreen_title: SwissCovid –\nfind out fast if you're at risk of infection.
     inform_detail_faq3_text: Yes, but although no personal data is sent out, it may well be that someone remembers their encounter with you from the date.
-    inform_detail_faq3_title: Does anyone find out who I am?
+    inform_detail_faq3_title: Do I stay anonymous?
     meldungen_detail_explanation_text4: When the first symptoms appear, phone a doctor or health centre.
     tracing_setting_text_android: COVID-19 Exposure Notifications
     onboarding_gaen_text_android: The tracing function must be activated to detect encounters.
@@ -311,7 +311,7 @@ en:
     travel_title: Travel
     travel_home_description: The SwissCovid encounters function works in the following countries:
     travel_screen_explanation_title_1: What does that mean?
-    travel_screen_explanation_text_1: You don’t have to install another app if you’re travelling in one of the compatible countries.\n\nSwissCovid checks private keys published in the compatible countries. This means that you can also receive alerts of possible infection abroad.
+    travel_screen_explanation_text_1: You don’t have to install another app for encounters if you’re travelling in one of the compatible countries.\n\nSwissCovid checks private keys published in the compatible countries. This means that you can also receive alerts of possible infection abroad.
     travel_screen_explanation_title_2: What happens when the Covidcode is entered?
     travel_screen_explanation_text_2: When the Covidcode is entered, the private keys sent by you are also shared with the compatible countries.\n\nTo enable travellers from abroad to also receive alerts, this happens regardless of whether you yourself are travelling abroad or not.
     accessibility_faq_button_hint_non_bag: This button leaves the app and opens a website.
@@ -328,8 +328,8 @@ en:
     share_app_supertitle: Together…
     share_app_title: against the spread of Covid
     share_app_button: Share app
-    share_app_body: If as many people as possible activate the SwissCovid app, we can break infection chains early.
-    share_app_message: If as many people as possible activate the SwissCovid app, we can break infection chains early.
+    share_app_body: If as many of your contacts as possible use the SwissCovid app you can be notified rapidly if there is a risk of infection.
+    share_app_message: By using the SwissCovid app, we can all help to contain the spread of the coronavirus.
     share_app_url: https://foph-coronavirus.ch/swisscovid-app/#download
     stats_counter: {COUNT} M
     stats_source_day: Stats as of {DAY}
@@ -469,7 +469,7 @@ en:
     homescreen_isolation_ended_popup_text: Tracing can be reactivated once you have completed your period of isolation.
     answer_yes: Yes
     answer_no: No
-    travel_screen_info: Travelling abroad? SwissCovid works in these countries.
+    travel_screen_info: Travelling abroad? SwissCovid encounters works in these countries.
     travel_screen_compatible_countries: Compatible countries:
     inform_code_travel_text: To enable travellers from abroad to receive alerts as well, the private keys are also shared with the coronavirus apps in compatible countries.
     stats_covidcodes_total_header: Total
@@ -478,9 +478,9 @@ en:
     meldungen_positive_tested_faq2_title: Who will be notified?
     meldungen_positive_tested_faq2_text: All the people you came into contact with during the infectious period from {ONSET_DATE} until you entered the Covidcode will be notified, if there is a possibility of infection due to the proximity and duration of the contact, or if you were checked-in at the same location.
     inform_send_thankyou_text_onsetdate: {ONSET_DATE} – today
-    inform_send_thankyou_text_stop_infection_chains: In this way you are helping alert others to a possible infection.
+    inform_send_thankyou_text_stop_infection_chains: In this way you are helping to alert others should there be a risk of infection.
     inform_send_thankyou_text_onsetdate_info: Your app's private key was sent for the following period:
-    android_inform_tracing_enabled_explanation: When you enter a Covidcode, tracing needs to be activated so that your private key can be shared.
+    inform_tracing_enabled_explanation: When you enter a Covidcode, tracing needs to be activated so that your private key can be shared.
     leitfaden_infopopup_text: If you press "{BUTTON_TITLE}", you leave the app and switch to the SwissCovid Guide website. The data on recent encounters with potentially infected people is sent to the website.
     leitfaden_infopopup_title: SwissCovid Guide information
     germany_update_boarding_title: Compatible with Germany
@@ -517,7 +517,7 @@ en:
     module_checkins_title: Check-in
     checkin_title: Check-in
     checkins_create_qr_code: Generate QR code
-    events_title: Offer check-ins?
+    events_title: Generate QR codes
     check_in_now_button_title: Check in now
     checkin_reminder_settings_alert_title: The reminder could not be set
     checkin_reminder_settings_alert_message: To receive check-out reminders, you need to allow \"notifications\" in the app settings.
@@ -564,27 +564,27 @@ en:
     print_button_title: Print
     module_checkins_description: Scan a SwissCovid QR code to check in on site.
     inform_share_checkins_title: Share check-in entries
-    inform_share_checkins_subtitle: If you share check-in entries, the app can notify people who were checked in at the same location at the same time.
-    inform_share_checkins_select_all: Select all
+    inform_share_checkins_subtitle: If you share check-in entries, the app can notify people who were checked in at the same location and time.
+    inform_share_checkins_select_all: Select all suitable
     inform_dont_send_button_title: Don't send
     inform_dont_share_button_title: Don't share
     inform_really_not_share_title: Are you sure you don't want to share?
-    inform_really_not_share_subtitle: Sharing your private key helps SwissCovid to notify other people who may be infected and to stop the virus spreading. If you don't share your private key, people who may be infected will not be notified.
+    inform_really_not_share_subtitle: Sharing your private key helps SwissCovid to notify other people who may be infected and helps to stop the virus spreading. If you don't share your private key, people who may be infected will not be notified.
     remove_diary_warning_title: Remove entry
     remove_diary_warning_text: Your entry will be permanently removed from the list.
-    remove_diary_remove_now_button: Completely remove
+    remove_diary_remove_now_button: Remove completely
     remove_diary_warning_hide_title: Only hide and keep receiving notifications?
     home_covidcode_card_title: Tested positive?
     home_end_isolation_card_text: Reactivate encounters and check-in
     reminder_option_hours_minutes: {HOURS} h {MINUTES}'
     checkin_overview_isolation_text: You can no longer check in if you have tested positive.
     events_card_subtitle: Generate a QR code that people can use to check in on site.
-    delete_qr_code_dialog: Are you sure you want to delete the QR code?
+    delete_qr_code_dialog: Are you sure you want to delete the QR code? Printed QR codes will remain valid.
     self_checkin_button_title: Self check-in
     checkin_overview_checkins_explanation: Scan a SwissCovid QR code to check in on site.
     checkout_overlapping_alert_title: Saving not possible
     checkout_overlapping_alert_description: The times you selected clash with other check-ins in your diary. Please check your entry.
-    inform_send_thankyou_text_checkins: The check-in entries you selected have been sent. Everyone who was checked in at the same location at the same time will be notified.
+    inform_send_thankyou_text_checkins: The check-in entries you selected have been sent. Everyone who was checked in at the same location and time will be notified.
     pdf_headline: SwissCovid check-in
     pdf_slogan: Check in without leaving any data
     pdf_explanation: The SwissCovid app lets you simply check in with us without leaving behind your data. If there is a risk of infection, you will be rapidly notified in the app.
@@ -593,19 +593,19 @@ en:
     checkin_detail_checked_out_title: Check in without leaving \ndata
     home_covidcode_card_text: Enter your Covidcode here to alert others.
     home_end_isolation_card_title: Isolation ended?
-    events_card_title: Do you want to offer check-ins?
-    checkin_footer_title1: Why a check-in function?
-    checkin_footer_subtitle1: The SwissCovid app has been upgraded to include the check-in function without entering contact details. If you test positive, this function lets you alert people who were checked in at the same location at the same time, as well as close contacts.
+    events_card_title: Want to generate QR codes?
+    checkin_footer_title1: Why a check-in feature?
+    checkin_footer_subtitle1: The SwissCovid app has been upgraded to include the check-in function without entering contact details. If you test positive, this function lets you alert not only close contacts, but also people who were checked in at the same location at the same time.
     checkin_footer_title2: No central data storage
     checkin_footer_subtitle2: For the SwissCovid check-ins, you don't have to enter personal details, such as name, address or phone number, and no GPS location data is recorded. The list of check-ins is stored locally on your device. The local data is deleted after 14 days. 
     events_empty_state_title: Generate a QR code
-    events_empty_state_subtitle: Using a SwissCovid QR code, people can check in on site without leaving their data.
+    events_empty_state_subtitle: With a SwissCovid QR code, people can check in on site without leaving their data.
     events_info_box_title: No substitute for mandatory recording of contact details
     events_info_box_text: SwissCovid check-ins are no substitute for the obligation to record contact details provided for in the COVID-19 Ordinance Special Situation. 
     events_footer_title1: Where can check-ins be used?
     events_footer_title2: Why a check-in function?
     events_footer_subtitle1: SwissCovid check-ins can be used where people gather but where there is no obligation to record contact details. \n\nPossible locations:\n– Private events\n– Club meetings or events\n– Gatherings in professional settings, e.g. meeting rooms, offices, canteens
-    events_footer_subtitle2: The SwissCovid app has been upgraded to include the check-in function without entering contact details. If you test positive, this function lets you alert people who were checked in at the same location at the same time, as well as close contacts.
+    events_footer_subtitle2: The SwissCovid app has been upgraded to include the check-in function without entering contact details. If you test positive, this function lets you alert not only close contacts, but also people who were checked in at the same location at the same time.
     meldung_detail_exposed_list_card_subtitle: Risk situation
     meldung_detail_exposed_list_card_title_encounters: Encounters
     meldung_detail_exposed_list_card_title_checkin: Check-in
@@ -622,7 +622,7 @@ en:
     checkin_report_title3: Get tested
     checkin_report_subtitle1: You may already be infectious without realising it. Follow the rules on hygiene and social distancing and protect your loved ones and those around you.
     checkin_report_subtitle2: Monitor your state of health.
-    checkin_report_subtitle3: If you develop symptoms, get tested immediately. Even if you don't have symptoms, a coronavirus test is advisable and recommended.
+    checkin_report_subtitle3: If you develop symptoms, get tested immediately. A coronavirus test is also advisable and recommended if you have no symptoms and are not yet fully vaccinated.
     meldung_detail_checkin_title: Check-in
     not_thank_you_screen_title: No data sent
     not_thank_you_screen_text1: No private key was sent.
@@ -634,14 +634,14 @@ en:
     onboarding_checkin_title: Check in without leaving data
     onboarding_checkin_heading: Check-ins
     onboarding_checkin_text1: With SwissCovid check-ins you can check in to a location or meeting using the app.
-    onboarding_checkin_text2: Your presence is only stored in the app. You don’t have to leave behind any personal data. 
+    onboarding_checkin_text2: Your presence is only stored in the app. You don’t have to leave behind any personal data.
     checkin_updateboarding_text: With SwissCovid check-ins you can check in to a location or meeting using the app. Your presence is only stored in the app. You don't have to leave behind any personal data. The terms of use and privacy policy have been updated.
     onboarding_gaen_button_dont_activate: Skip
     remove_diary_warning_hide_text: The entry is stored in encrypted form in the background of the app for 14 days. This means that you can still be notified if there is a possibility of infection.
     remove_diary_warning_hide_button: Hide only
     checkin_set_reminder_explanation: The app can remind you to check out at the right time.
     remove_diary_remove_now_title: Or remove completely?
-    remove_diary_remove_now_text: The entry was removed completely. You can no longer be alerted.
+    remove_diary_remove_now_text: The entry will be removed completely. You will no longer be alerted.
     not_thank_you_screen_text3: Nobody will be notified.
     checkin_report_link: What do I need to know about testing?
     instant_app_install_action: Install app and check in
@@ -651,4 +651,19 @@ en:
     partial_onboarding_done_text: Thank you for helping stop the spread of coronavirus.
     web_slogan: Find out fast if you're at risk of infection.
     test_info_url: https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/testen.html
-    checkout_too_long_alert_text: For this check-in a maximum check-in duration of {DURATION} applies. Please check your input again.
+    checkout_too_long_alert_text: The maximum duration of this check-in is {DURATION}. Please check your entry again.
+    accessibility_camera_light_on: Light on
+    accessibility_camera_light_off: Light off
+    error_cannot_enter_covidcode_while_checked_in: You are still checked in. Please check out before you enter the COVID code.
+    events_card_title_events_not_empty: My QR codes
+    checkout_inverse_time_alert_description: Your selected check-out time is before the check-in time. Please check your entry again.
+    update_notification_checkin_feature_title: New function: check-in
+    update_notification_checkin_feature_text: Thanks for using SwissCovid. With the latest version of the app you can check in at a venue without leaving a data trail.
+    diary_current_title: Current
+    ios_snooze_option_30min: Remind again [oder: Snooze??] (30min)
+    ios_snooze_option_1h: Remind again [oder: Snooze??] (1h)
+    ios_snooze_option_2h: Remind again [oder: Snooze??] (2h)
+    ios_notification_checkout_now: Check out now
+    covid_certificate_alert_text: Please use the COVID Certificate app to scan this QR code.
+    covid_certificate_open_app: Open app
+    covid_certificate_install_app: Install app

--- a/dpppt-config-backend/src/main/resources/i18n/messages_es.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_es.properties
@@ -115,7 +115,7 @@ es:
     app_subtitle: (Subtitle)
     onboarding_prinzip_heading: El objetivo:
     onboarding_prinzip_title: Anticiparnos al virus
-    onboarding_prinzip_text1: Con la aplicación Swiss Covid, todos podemos contribuir a contener la propagación del virus.
+    onboarding_prinzip_text1: Con la aplicación SwissCovid, todos podemos contribuir a contener la propagación del virus.
     onboarding_prinzip_text2: La aplicación le avisa si ha estado usted potencialmente expuesto al coronavirus.
     onboarding_privacy_heading: Privacy by design
     onboarding_privacy_title: Protección de la esfera privada
@@ -254,7 +254,7 @@ es:
     gaen_not_aviable: Google Play Services no actualizado
     gaen_not_available_text: Actualice Google Play Services
     gaen_unexpectedly_disabled: Se ha desactivado el rastreo. Vuelva a iniciarlo.
-    tracing_permission_error_title_ios: Notificaciones de exposición a la COVID-19 desactivado desactivado
+    tracing_permission_error_title_ios: Notificaciones de exposición a la COVID-19 desactivado
     tracing_permission_error_text_ios: Active {TRACING_SETTING_TEXT} para que el rastreo anónimo pueda funcionar.
     user_cancelled_key_sharing_error: No se ha podido enviar el mensaje. Autorice el intercambio de su ID aleatoria con la app SwissCovid.
     playservices_update: Actualizar
@@ -311,14 +311,14 @@ es:
     travel_title: Viajar
     travel_home_description: La función SwissCovid-Contactos funciona en los países siguientes:
     travel_screen_explanation_title_1: ¿Y esto qué significa?
-    travel_screen_explanation_text_1: Si está usted de viaje en uno de los países compatibles no es necesario descargar otra aplicación contra el coronavirus.\n\nSwissCovid analiza las claves privadas difundidas en los países compatibles. Así, la aplicación le avisa de un posible contagio incluso estando en el extranjero.
+    travel_screen_explanation_text_1: Si está usted de viaje en uno de los países compatibles, no es necesario descargar otra aplicación para los contactos.\n\nSwissCovid analiza las claves privadas difundidas en los países compatibles. Así, la aplicación le avisa de un posible contagio incluso estando en el extranjero.
     travel_screen_explanation_title_2: ¿Qué ocurre al introducir el código Covid?
     travel_screen_explanation_text_2: Al introducir el código Covid, las claves privadas que usted envía se comparten también con los países compatibles.\n\nAl fin de poder alertar también a los viajeros del extranjero, esto ocurre independientemente de que usted haya estado en el extranjero o no. 
     accessibility_faq_button_hint_non_bag: Este botón sale de la aplicación y abre una página web.
     begegnung_detail_no_last_sync_accessibility: No hay sincronizaciones previas.
     meldungen_background_error_text_android: Cambie los ajustes para recibir las notificaciones más actuales también fuera de la aplicación.
     infoline_coronavirus_number: +41 58 387 77 80
-    tracing_setting_text_ios_14_0: Exposure Notifications
+    tracing_setting_text_ios_14_0: Notificaciones de exposición
     bottom_nav_tab_home: SwissCovid
     bottom_nav_tab_stats: Datos
     stats_title: ya utilizan SwissCovid
@@ -328,8 +328,8 @@ es:
     share_app_supertitle: Juntos…
     share_app_title: evitamos los contagios
     share_app_button: Compartir la aplicación
-    share_app_body: Si un gran número de personas activan la app SwissCovid, es posible interrumpir las cadenas de contagio a tiempo.
-    share_app_message: Si un gran número de personas activan la app SwissCovid, es posible interrumpir las cadenas de contagio a tiempo.
+    share_app_body: Cuantas más personas de entre sus contractos utilicen la app SwissCovid, más rápidamente será informado de un riesgo de contagio.
+    share_app_message: Con la aplicación SwissCovid, todos podemos contribuir a contener la propagación del virus.
     share_app_url: https://bag-coronavirus.ch/swisscovid-app/#download
     stats_counter: {COUNT} millones
     stats_source_day: Datos actualizados el {DAY}
@@ -469,7 +469,7 @@ es:
     homescreen_isolation_ended_popup_text: El rastreo puede ser activado de nuevo tan pronto como haya terminado el aislamiento.
     answer_yes: Sí
     answer_no: No
-    travel_screen_info: ¿En el extranjero? SwissCovid funciona en estos países.
+    travel_screen_info: ¿En el extranjero? SwissCovid-Contactos funciona en estos países.
     travel_screen_compatible_countries: Países compatibles:
     inform_code_travel_text: A fin de alertar también a viajeros del extranjero tras un contacto, las claves privadas se comparten con las aplicaciones contra el coronavirus de países compatibles.
     stats_covidcodes_total_header: Total
@@ -480,7 +480,7 @@ es:
     inform_send_thankyou_text_onsetdate: {ONSET_DATE} – hoy
     inform_send_thankyou_text_stop_infection_chains: Así está contribuyendo a avisar a otras personas de un posible contagio.
     inform_send_thankyou_text_onsetdate_info: Las claves privadas de su aplicación se han enviado para el periodo siguiente:
-    android_inform_tracing_enabled_explanation: El rastreo debe estar activado al introducir el código Covid para permitir el intercambio de las claves privadas.
+    inform_tracing_enabled_explanation: El rastreo debe estar activado al introducir el código Covid para permitir el intercambio de las claves privadas.
     leitfaden_infopopup_text: Al pulsar "{BUTTON_TITLE}", abandonará la app para ir a la página web de la Guía SwissCovid. En este proceso, también se transmitirán a la página web los datos de los últimos contactos en los que posiblemente haya habido contagio.
     leitfaden_infopopup_title: Información sobre la Guía SwissCovid
     germany_update_boarding_title: Compatible con Alemania
@@ -506,7 +506,7 @@ es:
     reminder_option_off: Off
     authenticate_for_diary: Autentifíquese para acceder al diario
     reminder_option_hours: {HOURS} h
-    reminder_option_minutes: {HOURS} h
+    reminder_option_minutes: {MINUTES}'
     qr_scanner_no_camera_permission: La app debe acceder a la cámara del dispositivo para poder escanear el código QR.
     diary_title: Mis Check-in
     checkin_button_title: Check-in
@@ -517,7 +517,7 @@ es:
     module_checkins_title: Check-in
     checkin_title: Check-in
     checkins_create_qr_code: Generar código QR
-    events_title: ¿Quiere ofrecer Check-in a otros?
+    events_title: Generar códigos QR
     check_in_now_button_title: Check-in ahora
     checkin_reminder_settings_alert_title: No se podido fijar el recordatorio
     checkin_reminder_settings_alert_message: Para poder recibir los recordatorios para el registro de salida, debe habilitar \"Notificaciones\" en los ajustes de la aplicación. 
@@ -565,7 +565,7 @@ es:
     module_checkins_description: Escanee un código QR SwissCovid para hacer el registro de entrada in situ.
     inform_share_checkins_title: Compartir registros de Check-in
     inform_share_checkins_subtitle: Al compartir los registros de Check-in, la aplicación puede informar a personas que se registraron al mismo tiempo en el mismo sitio.
-    inform_share_checkins_select_all: Seleccionar todos
+    inform_share_checkins_select_all: Seleccionar todo lo apropiado
     inform_dont_send_button_title: No enviar
     inform_dont_share_button_title: No compartir
     inform_really_not_share_title: ¿Seguro que no quiere compartir?
@@ -578,8 +578,8 @@ es:
     home_end_isolation_card_text: Volver a activar contactos y Check-in
     reminder_option_hours_minutes: {HOURS} h {MINUTES}'
     checkin_overview_isolation_text: No puede usted hacer un registro de entrada si ha dado positivo en el test.
-    events_card_subtitle: Genere un código QR para permitir que las personas puedan registrase in situ.
-    delete_qr_code_dialog: ¿Seguro que quiere eliminar el código QR?
+    events_card_subtitle: Genere un código QR-SwissCovid para permitir que las personas puedan registrase in situ.
+    delete_qr_code_dialog: ¿Seguro que quiere eliminar el código QR? Los códigos QR impresos mantienen su vigencia.
     self_checkin_button_title: Auto Check-in
     checkin_overview_checkins_explanation: Escanee un código QR SwissCovid para registrarse in situ.
     checkout_overlapping_alert_title: No es posible guardar
@@ -593,7 +593,7 @@ es:
     checkin_detail_checked_out_title: Registro de entrada sin dejar datos
     home_covidcode_card_text: Introduzca aquí el código Covid para alertar a otras personas.
     home_end_isolation_card_title: ¿Finalizado el aislamiento?
-    events_card_title: ¿Quiere usted ofrecer Check-in a otros?
+    events_card_title: ¿Quiere usted generar códigos QR?
     checkin_footer_title1: ¿Por qué una función Check-in?
     checkin_footer_subtitle1: La función Check-in sin registro de datos de contacto es una ampliación de la app SwissCovid. En caso de dar positivo en un test, esta función le permite alertar no solo a los contactos estrechos, sino también a personas que se registraron al mismo tiempo en el mismo lugar que usted.
     checkin_footer_title2: Sin almacenamiento centralizado de datos
@@ -601,10 +601,10 @@ es:
     events_empty_state_title: Genere un código QR
     events_empty_state_subtitle: Con un código QR SwissCovid es posible registrarse in situ sin necesidad de dejar datos personales.
     events_info_box_title: No sustituye el registro obligatorio de los datos de contacto
-    events_info_box_text: Los Check-in SwissCovid nos sustituyen el registro obligatorio de los datos de contacto estipulado en la «Ordenanza Covid-19, situación particular». 
+    events_info_box_text: Los Check-in SwissCovid no sustituyen el registro obligatorio de los datos de contacto estipulado en la «Ordenanza Covid-19, situación particular».
     events_footer_title1: ¿Dónde utilizar los Check-in?
     events_footer_title2: ¿Por qué una función Check-in?
-    events_footer_subtitle1: Los Check-in SwissCovid puede utilizarse allí donde las personas se reúnen pero el registro de los datos de contacto no es obligatorio.\n\nPosibles utilizaciones:\n– eventos privados\n– eventos de asociaciones\n– reuniones en el entorno laboral, por ej. salas de reuniones, oficinas, cantinas, etc.
+    events_footer_subtitle1: Los Check-in SwissCovid pueden utilizarse allí donde las personas se reúnen pero el registro de los datos de contacto no es obligatorio.\n\nPosibles utilizaciones:\n– eventos privados\n– eventos de asociaciones\n– reuniones en el entorno laboral, por ej. salas de reuniones, oficinas, cantinas, etc.
     events_footer_subtitle2: La función Check-in sin registro de datos de contacto es una ampliación de la app SwissCovid. En caso de dar positivo en un test, esta función le permite alertar no solo a los contactos estrechos, sino también a personas que se registraron al mismo tiempo
     meldung_detail_exposed_list_card_subtitle: Situaciones de riesgo
     meldung_detail_exposed_list_card_title_encounters: Contactos
@@ -622,7 +622,7 @@ es:
     checkin_report_title3: Hacer el test
     checkin_report_subtitle1: Es posible que sea usted contagioso sin darse cuenta. Observe las reglas de higiene y comportamiento y proteja a su familia, sus amigos y su entorno.
     checkin_report_subtitle2: Vigile su estado de salud.
-    checkin_report_subtitle3: Ante la aparición de síntomas haga el test inmediatamente. Incluso si no tiene síntomas, es oportuno y recomendable hacer el test de Covid-19.
+    checkin_report_subtitle3: Ante la aparición de síntomas haga el test inmediatamente. Incluso si no tiene síntomas y aún no está vacunado por completo, es conveniente y recomendable hacer el test del coronavirus.
     meldung_detail_checkin_title: Check-in
     not_thank_you_screen_title: No se han enviado datos
     not_thank_you_screen_text1: No se han enviado claves privadas.
@@ -634,7 +634,7 @@ es:
     onboarding_checkin_title: Check-in sin dejar datos
     onboarding_checkin_heading: Registros de Check-in
     onboarding_checkin_text1: La función Check-in SwissCovid le permite registrarse con la aplicación en un lugar o en un evento.
-    onboarding_checkin_text2: Su presencia solo queda registra en la aplicación. No es necesario indicar datos personales en la app.
+    onboarding_checkin_text2: Su presencia solo queda registrada en la aplicación. No es necesario indicar datos personales en la app.
     checkin_updateboarding_text: La función Check-in SwissCovid le permite registrarse con la aplicación en un lugar o en un evento. Su presencia solo queda registrada en la aplicación. No es necesario indicar datos personales en la app. A estos efectos se han actualizado las condiciones de uso y la política de privacidad.
     onboarding_gaen_button_dont_activate: Omitir
     remove_diary_warning_hide_text: El registro permanece codificado en la aplicación en segundo plano durante 14 días. En caso de un posible contagio puede usted recibir un aviso.
@@ -651,3 +651,19 @@ es:
     partial_onboarding_done_text: Gracias por contribuir a contener la propagación del coronavirus.
     web_slogan: Información rápida ante un riesgo de contagio.
     test_info_url: https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/testen.html
+    checkout_too_long_alert_text: Este Check-In tiene una duración máxima de {DURATION}. Por favor, compruebe los datos introducidos.
+    accessibility_camera_light_on: Luz encendida
+    accessibility_camera_light_off: Luz apagada
+    error_cannot_enter_covidcode_while_checked_in: Aún no ha hecho el Check-in. Dése de baja antes de introducir el código Covid.
+    events_card_title_events_not_empty: Mis códigos QR
+    checkout_inverse_time_alert_description: La hora de Chek-out seleccionada es anterior a la de Check-in. Por favor, compruebe los datos introducidos.
+    update_notification_checkin_feature_title: Nueva función: Check-in
+    update_notification_checkin_feature_text: Gracias por utilizar SwissCovid. Con la nueva versión de la aplicación puede usted registrarse en un lugar sin dejar ningún dato.
+    diary_current_title: Ahora
+    ios_snooze_option_30min: Volver a recordar (30 min)
+    ios_snooze_option_1h: Volver a recordar (1 h)
+    ios_snooze_option_2h: Volver a recordar (2 h)
+    ios_notification_checkout_now: Check-out ahora
+    covid_certificate_alert_text: Para escanear este código QR utilice la aplicación "COVID Certificate".
+    covid_certificate_open_app: Abrir la aplicación
+    covid_certificate_install_app: Instalar la aplicación

--- a/dpppt-config-backend/src/main/resources/i18n/messages_fr.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_fr.properties
@@ -21,8 +21,8 @@ fr:
     bluetooth_permission_turned_off: L'application ne fonctionne pas, car Bluetooth n'a pas reçu l'autorisation nécessaire.
     NSBluetoothPeripheralUsageDescription: Les contacts sont détectés en arrière-plan via Bluetooth (faible consommation).
     NSBluetoothAlwaysUsageDescription: Les contacts sont détectés en arrière-plan via Bluetooth (faible consommation).
-    inform_code_title: Entrer le code COVID
-    inform_code_text: Entrez le code COVID reçu.
+    inform_code_title: Saisir le code COVID
+    inform_code_text: Saisissez le code COVID reçu.
     inform_code_no_code: Besoin d'aide ?
     tracing_setting_title: Traçage de proximité
     tracing_setting_text_ios: Notifications d'exposition
@@ -63,7 +63,7 @@ fr:
     inform_detail_title: test positif ?
     inform_detail_box_subtitle: Avec le code COVID…
     inform_detail_box_title: Avertir d’une infection possible
-    inform_detail_box_button: Entrer le code COVID
+    inform_detail_box_button: Saisir le code COVID
     inform_detail_box_text: En saisissant le code COVID, vous indiquez à l'application que vous avez été testé positif au nouveau coronavirus.
     symptom_detail_subtitle: Que faire si…
     symptom_detail_title: je me sens malade ?
@@ -90,8 +90,8 @@ fr:
     meldung_detail_positive_test_box_subtitle: Que dois-je faire ?
     meldung_detail_positive_test_box_title: Isolement
     meldung_detail_positive_test_box_text: Suivez les consignes reçues sur l'isolement.
-    tracing_ended_title: Contacts et connexion désactivés
-    tracing_ended_text: Aucune contact n’est sauvegardé.
+    tracing_ended_title: Contacts et check-ins désactivés
+    tracing_ended_text: Aucun contact n’est sauvegardé.
     exposed_info_contact_hotline: Contactez
     meldung_homescreen_positive_info_line1: Suivez
     meldung_homescreen_positive_info_line2: Consignes sur l’isolement
@@ -209,7 +209,7 @@ fr:
     inform_detail_faq1_title: Qu'est-ce qu'un code COVID ?
     inform_detail_faq1_text: Les personnes testées positives au coronavirus (test PCR ou test rapide antigénique) reçoivent un code COVID.\n\nCeci permet de garantir que seuls les cas confirmés sont déclarés dans l'application.
     inform_detail_faq2_title: Qu'est-ce qui est envoyé ?
-    inform_detail_faq2_text: Seules les clés privées de votre application et les identifiants codés de vos connexions sont transmises, aucune donnée personnelle.\n\nAinsi, d’autres utilisateurs de l’application SwissCovid apprennent qu’il y a un risque d’infection.\n
+    inform_detail_faq2_text: Seules les clés privées de votre application et les identifiants codés de vos check-ins sont transmises, aucune donnée personnelle.\n\nAinsi, d’autres utilisateurs de l’application SwissCovid apprennent qu’il y a un risque d’infection.\n
     infoline_tel_number: +41 58 387 77 78
     faq_button_url: https://www.bag.admin.ch/bag/fr/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/faq-kontakte-downloads/haeufig-gestellte-fragen.html?faq-url=/fr/categories/application-swisscovid
     inform_code_intro_title: Information concernant la saisie
@@ -311,7 +311,7 @@ fr:
     travel_title: Voyages
     travel_home_description: SwissCovid fonctionne dans les pays suivants :
     travel_screen_explanation_title_1: Qu'est-ce que cela signifie ?
-    travel_screen_explanation_text_1: Si vous voyagez dans un des pays compatibles, vous n'avez pas besoin d'installer une autre application. \n\nSwissCovid vérifie les clés privées publiées dans les pays compatibles. Ainsi, vous serez averti d'une infection possible à l'étranger également.
+    travel_screen_explanation_text_1: Si vous voyagez dans un des pays compatibles, vous n'avez pas besoin d'installer une autre application pour les contacts. \n\nSwissCovid vérifie les clés privées publiées dans les pays compatibles. Ainsi, vous serez averti d'une infection possible à l'étranger également.
     travel_screen_explanation_title_2: Que se passe-t-il quand je saisis le code COVID ?
     travel_screen_explanation_text_2: Lorsque vous saisissez le code COVID, les clés privées que vous avez envoyées sont partagées avec les pays compatibles également.\n\nCet envoi se produit que vous ayez été à l'étranger ou non afin de pouvoir avertir les voyageurs en provenance d'autres pays.
     accessibility_faq_button_hint_non_bag: Ce bouton permet de quitter l'application et\nd'ouvrir un site internet.
@@ -328,8 +328,8 @@ fr:
     share_app_supertitle: Ensemble…
     share_app_title: empêcher les contaminations
     share_app_button: Partager l'application
-    share_app_body: Si un maximum de personnes activent l'application SwissCovid, nous pouvons interrompre rapidement les chaînes d'infection.
-    share_app_message: Si un maximum de personnes activent l'application SwissCovid, nous pouvons interrompre rapidement les chaînes d'infection.
+    share_app_body: Si de nombreuses personnes utilisent l'application SwissCovid autour de vous, vous pourrez être alerté rapidement lors d'un risque d'infection.
+    share_app_message: Grâce à l'application SwissCovid, tout le monde peut contribuer à endiguer la propagation du virus.
     share_app_url: https://ofsp-coronavirus.ch/application-swisscovid/#download
     stats_counter: {COUNT} millions
     stats_source_day: État des données {DAY}
@@ -469,7 +469,7 @@ fr:
     homescreen_isolation_ended_popup_text: Le traçage peut être réactivé dès que votre isolement prend fin.
     answer_yes: Oui
     answer_no: Non
-    travel_screen_info: En voyage à l'étranger ? SwissCovid fonctionne dans ces pays.
+    travel_screen_info: En voyage à l'étranger ? Les contacts SwissCovid fonctionnent dans ces pays.
     travel_screen_compatible_countries: Pays compatibles :
     inform_code_travel_text: Afin que les voyageurs en provenance de l’étranger puissent aussi être avertis, les clés privées sont partagées avec les applications des pays compatibles.
     stats_covidcodes_total_header: Total
@@ -480,7 +480,7 @@ fr:
     inform_send_thankyou_text_onsetdate: {ONSET_DATE} – aujourd'hui
     inform_send_thankyou_text_stop_infection_chains: Vous contribuez ainsi à avertir d’autres utilisateurs d’une possible infection.
     inform_send_thankyou_text_onsetdate_info: Les clés privées de votre application ont été envoyées pour la période suivante :
-    android_inform_tracing_enabled_explanation: Le traçage doit être activé lors de la saisie d'un code COVID, afin que les clés privées puissent être envoyées.
+    inform_tracing_enabled_explanation: Le traçage doit être activé lors de la saisie d'un code COVID, afin que les clés privées puissent être envoyées.
     leitfaden_infopopup_text: En cliquant sur "{BUTTON_TITLE}", vous quitterez l'application et serez redirigé sur le site du guide SwissCovid. Les dates de vos derniers contacts avec des personnes potentiellement infectées seront alors transmises au site.
     leitfaden_infopopup_title: Information Guide SwissCovid
     germany_update_boarding_title: Compatible avec l'Allemagne
@@ -491,10 +491,10 @@ fr:
     meldungen_detail_free_test_in_x_tagen: Dans {COUNT} jours
     meldungen_detail_free_test_now: Maintenant
     meldungen_detail_free_test_tomorrow: Dans 1 jour
-    checkout_reminder_title: Rappel de déconnexion
+    checkout_reminder_title: Rappel de check-out
     checkout_reminder_text: Souhaitez-vous vous déconnecter ?
-    auto_checkout_title: Déconnexion automatique
-    auto_checkout_body: Il y a eu une déconnexion automatique.
+    auto_checkout_title: Check-out automatique
+    auto_checkout_body: Il y a eu un check-out automatique.
     qrscanner_scan_qr_text: Scanner le code QR et se connecter
     qrscanner_error: Code QR invalide !
     datepicker_from: De
@@ -502,30 +502,30 @@ fr:
     edit_mode_addcomment: Ajouter une mention
     edit_mode_comment_placeholder: P. ex. qui vous a accompagné ?
     done_button: Fin
-    checkin_set_reminder: Rappel de déconnexion
-    reminder_option_off: Arrêter
+    checkin_set_reminder: Rappel de check-out
+    reminder_option_off: Off
     authenticate_for_diary: Veuillez vous authentifier pour accéder au journal
     reminder_option_hours: {HOURS} h
     reminder_option_minutes: {MINUTES}'
     qr_scanner_no_camera_permission: L'application doit avoir accès à l'appareil photo pour pouvoir scanner le code QR.
-    diary_title: Mes connexions
-    checkin_button_title: Connexion
+    diary_title: Mes check-ins
+    checkin_button_title: Check-in
     NSCameraUsageDescription: L’appareil photo est nécessaire pour scanner le code QR.
     NSFaceIDUsageDescription: Autorisez la reconnaissance faciale pour accéder à votre journal en toute sécurité.
     face_id_reason_text: Veuillez vous authentifier pour accéder au journal
-    checkout_button_title: Déconnexion
-    module_checkins_title: Connexion
-    checkin_title: Connexion
+    checkout_button_title: Check-out
+    module_checkins_title: Check-in
+    checkin_title: Check-in
     checkins_create_qr_code: Créer un code QR
-    events_title: Proposer des connexions ?
+    events_title: Créer un code QR
     check_in_now_button_title: Se connecter 
     checkin_reminder_settings_alert_title: Le rappel n’a pas pu être activé.
-    checkin_reminder_settings_alert_message: Afin de recevoir un rappel de déconnexion, vous devez autoriser la fonction \"Notifications\" dans les paramètres de l’application.
+    checkin_reminder_settings_alert_message: Afin de recevoir un rappel de check-out, vous devez autoriser la fonction \"Notifications\" dans les paramètres de l’application.
     checkin_reminder_option_open_settings: Adapter
     edit_controller_title: Traiter
     empty_diary_title: Il n'existe aucune donnée.
     empty_diary_text: Si vous scannez un code QR SwissCovid pour vous connecter sur place, une donnée est automatiquement enregistrée.
-    camera_permission_dialog_text: SwissCovid doit avoir accès à l’appareil photo de votre smartphone. L’appareil photo est uniquement utilisé pour scanner les codes QR.
+    camera_permission_dialog_text: SwissCovid doit avoir accès à l’appareil photo de votre smartphone. L’appareil photo est uniquement utilisé pour scanner les QR codes.
     camera_permission_dialog_action: Autoriser l’accès à l’appareil photo
     web_generator_title_placeholder: P. ex. lieu de rencontre ou nom de l’événement
     show_pdf_button: Imprimer le PDF
@@ -541,31 +541,31 @@ fr:
     error_title: Erreur
     qr_scanner_error_code_not_yet_valid: Le code QR n’est pas encore valable.
     qr_scanner_error_code_not_valid_anymore: Le code QR n’est plus valable.
-    error_already_checked_in: Votre connexion a déjà été établie.
+    error_already_checked_in: Votre check-in a déjà été établie.
     error_update_text: Ce code QR n'est pas compatible avec la version installée de l’application. Veuillez mettre à jour l’application.
     error_update_title: Mise à jour requise
     error_action_update: Mettre à jour 
     ongoing_notification_checkout_quick_action: Déconnecter
     reminder_notification_snooze_action: Fonction de rappel
-    android_ongoing_checkin_notification_channel_name: Notification de connexion permanente
-    ongoing_notification_title: Connexion activée depuis {TIME} heures.
+    android_ongoing_checkin_notification_channel_name: Notification de check-in permanente
+    ongoing_notification_title: Check-in activé depuis {TIME} heures.
     checkout_save_button_title: Sauvegarder
     scan_qr_code_button_title: Scanner le code QR
-    checkin_ended_title: Connexion désactivée
-    checkin_ended_text: Pas de connexion possible actuellement
-    checkin_detail_checked_out_text: Scannez un code QR SwissCovid pour vous connecter sur place.
+    checkin_ended_title: Check-in désactivé
+    checkin_ended_text: Pas de check-in possible actuellement
+    checkin_detail_checked_out_text: Scannez un QR code SwissCovid pour vous connecter sur place.
     checkin_detail_diary_text: Si vous scannez un code QR SwissCovid pour vous connecter sur place, une donnée est automatiquement enregistrée.
-    checkin_checked_in: Connexion effectuée
+    checkin_checked_in: Check-in effectué
     checkout_from_to_date: Du {DATE1} au {DATE2}
     inform_detail_covidcode_info_button: Plus d’informations sur le code COVID
     remove_from_diary_button: Effacer la donnée enregistrée
     delete_button_title: Effacer
     share_button_title: Partager
     print_button_title: Imprimer
-    module_checkins_description: Scannez un code QR SwissCovid pour vous connecter sur place.
-    inform_share_checkins_title: Partager les données de connexion
-    inform_share_checkins_subtitle: Si vous partagez vos données de connexion, l’application peut notifier les personnes qui étaient connectées au même endroit et à la même heure.
-    inform_share_checkins_select_all: Sélectionner tous
+    module_checkins_description: Scannez un QR code SwissCovid pour vous connecter sur place.
+    inform_share_checkins_title: Partager les données de check-ins
+    inform_share_checkins_subtitle: Si vous partagez vos données de check-in, l’application peut notifier les personnes qui étaient connectées au même endroit et à la même heure.
+    inform_share_checkins_select_all: Tout sélectionner
     inform_dont_send_button_title: Ne pas transmettre
     inform_dont_share_button_title: Ne pas partager
     inform_really_not_share_title: Ne voulez-vous vraiment pas partager les données ?
@@ -574,18 +574,18 @@ fr:
     remove_diary_warning_text: La donnée a été définitivement effacée de la liste.
     remove_diary_remove_now_button: Effacer définitivement
     remove_diary_warning_hide_title: Masquer uniquement et maintenir en vigueur les notifications ?
-    home_covidcode_card_title: Test positif ?
-    home_end_isolation_card_text: Réactiver contacts et connexions.
+    home_covidcode_card_title: Test positif?
+    home_end_isolation_card_text: Réactiver contacts et check-ins.
     reminder_option_hours_minutes: {HOURS} h {MINUTES}'
     checkin_overview_isolation_text: Vous ne pouvez plus vous connecter après un test positif.
-    events_card_subtitle: Créez un code QR permettant aux utilisateurs de se connecter sur place.
-    delete_qr_code_dialog: Souhaitez-vous vraiment supprimer le code QR ?
-    self_checkin_button_title: Auto-connexion
-    checkin_overview_checkins_explanation: Scannez un code QR SwissCovid pour vous connecter sur place.
+    events_card_subtitle: Créez un code QR SwissCovid permettant aux utilisateurs de se connecter sur place.
+    delete_qr_code_dialog: Souhaitez-vous vraiment supprimer le QR code? Les codes QR imprimés restent valides.
+    self_checkin_button_title: Auto-check-in
+    checkin_overview_checkins_explanation: Scannez un QR code SwissCovid pour vous connecter sur place.
     checkout_overlapping_alert_title: Sauvegarde impossible
-    checkout_overlapping_alert_description: Les heures sélectionnées coïncident avec d’autres connexions dans votre journal. Vérifiez encore une fois votre saisie.
-    inform_send_thankyou_text_checkins: Les données de connexion sélectionnées ont été transmises. Toutes les personnes qui étaient connectées au même endroit à la même heure seront notifiées.
-    pdf_headline: Connexion SwissCovid
+    checkout_overlapping_alert_description: Les heures sélectionnées coïncident avec d’autres check-ins dans votre journal. Vérifiez encore une fois votre saisie.
+    inform_send_thankyou_text_checkins: Les données de check-in sélectionnées ont été transmises. Toutes les personnes qui étaient connectées au même endroit à la même heure seront notifiées.
+    pdf_headline: SwissCovid Check-in
     pdf_slogan: Se connecter sans enregistrer de données
     pdf_explanation: Avec l’application SwissCovid, vous pouvez facilement vous connecter, sans enregistrer vos données. L’application vous informera rapidement d’un éventuel risque d’infection.
     pdf_swisscovid_app: Application SwissCovid
@@ -593,49 +593,49 @@ fr:
     checkin_detail_checked_out_title: Se connecter sans enregistrer de données
     home_covidcode_card_text: Saisissez ici votre code COVID pour alerter d’autres utilisateurs.
     home_end_isolation_card_title: Fin de l’isolement ?
-    events_card_title: Souhaitez-vous proposer des connexions ?
-    checkin_footer_title1: À quoi sert la fonction de connexion ?
-    checkin_footer_subtitle1: La fonction de connexion sans enregistrement des coordonnées complète l’application SwissCovid. En cas de test positif, elle vous permet d’avertir non seulement vos proches, mais aussi les personnes qui étaient présentes au même endroit au même moment.
+    events_card_title: Vous souhaitez créer un code QR ?
+    checkin_footer_title1: À quoi sert la fonction de check-in?
+    checkin_footer_subtitle1: La fonction de check-in sans enregistrement des coordonnées complète l’application SwissCovid. En cas de test positif, elle vous permet d’avertir non seulement vos proches, mais aussi les personnes qui étaient présentes au même endroit au même moment.
     checkin_footer_title2: Pas de sauvegarde centralisée des données
-    checkin_footer_subtitle2: La fonction de connexion SwissCovid ne nécessite pas la saisie de coordonnées comme le nom, l’adresse ou le numéro de téléphone et elle n’enregistre pas les données de géolocalisation. La liste des connexions est enregistrée localement sur votre smartphone. Les données locales sont effacées après 14 jours.
+    checkin_footer_subtitle2: La fonction des SwissCovid check-ins ne nécessite pas la saisie de coordonnées comme le nom, l’adresse ou le numéro de téléphone et elle n’enregistre pas les données de géolocalisation. La liste des check-ins est enregistrée localement sur votre smartphone. Les données locales sont effacées après 14 jours.
     events_empty_state_title: Créer un code QR
-    events_empty_state_subtitle: Au moyen du code QR SwissCovid, il est possible de se connecter sur place sans devoir enregistrer ses données.
+    events_empty_state_subtitle: Avec un code QR SwissCovid, il est possible de se connecter sur place sans devoir enregistrer ses données.
     events_info_box_title: Cette fonction ne remplace pas la collecte obligatoire des coordonnées.
-    events_info_box_text: La connexion SwissCovid ne remplace la collecte des coordonnées prescrite par l’« ordonnance COVID-19 situation particulière ».
-    events_footer_title1: Où la fonction de connexion peut-elle être utilisée ?
-    events_footer_title2: À quoi sert la fonction de connexion ?
-    events_footer_subtitle1: La fonction de connexion SwissCovid sera utile lors de rencontres dans des lieux où la collecte des coordonnées n’est pas obligatoire. Il peut s’agir – de rencontres privées – d’événements organisés par des associations – de rassemblements dans le cadre professionnel, p. ex. salles de réunion, bureaux, cantines, etc.
-    events_footer_subtitle2: La fonction de connexion sans enregistrement des coordonnées complète l’application SwissCovid. En cas de test positif, elle vous permet d’avertir non seulement vos proches, mais aussi les personnes qui étaient présentes au même endroit au même moment.
+    events_info_box_text: Les check-ins SwissCovid ne remplacent pas la collecte des coordonnées prescrite par l’« ordonnance COVID-19 situation particulière ».
+    events_footer_title1: Où la fonction de check-in peut-elle être utilisée?
+    events_footer_title2: À quoi sert la fonction de check-in?
+    events_footer_subtitle1: La fonction de check-in SwissCovid sera utile lors de rencontres dans des lieux où la collecte des coordonnées n’est pas obligatoire. Il peut s’agir – de rencontres privées – d’événements organisés par des associations – de rassemblements dans le cadre professionnel, p. ex. salles de réunion, bureaux, cantines, etc.
+    events_footer_subtitle2: La fonction de check-in sans enregistrement des coordonnées complète l’application SwissCovid. En cas de test positif, elle vous permet d’avertir non seulement vos proches, mais aussi les personnes qui étaient présentes au même endroit au même moment.
     meldung_detail_exposed_list_card_subtitle: Situations à risque
     meldung_detail_exposed_list_card_title_encounters: Contacts
-    meldung_detail_exposed_list_card_title_checkin: Connexion
+    meldung_detail_exposed_list_card_title_checkin: Check-in
     meldung_detail_exposed_list_card_whattodo_button: Que dois-je faire ?
-    debug_state_setting_option_checkin_exposed: Connexion positive
-    debug_state_setting_option_mutiple_exposed: Connexions / contacts positifs
-    venue_type_user_qr_code: Code QR de l’utilisateur
-    venue_type_contact_tracing_qr_code: Code QR de traçage des contacts
-    checkin_ended_text_detailed: Après un test positif, la fonction de connexion est automatiquement désactivée. Elle peut être réactivée après la fin de l’isolement.
-    checkins_create_qr_code_subtitle: Saisissez un titre qui décrit le lieu ou l’événement. Ce titre s’affichera lors de la connexion.
+    debug_state_setting_option_checkin_exposed: Check-in positif
+    debug_state_setting_option_mutiple_exposed: Check-ins / contacts positifs
+    venue_type_user_qr_code: QR code de l’utilisateur
+    venue_type_contact_tracing_qr_code: QR code de traçage des contacts
+    checkin_ended_text_detailed: Après un test positif, la fonction de check-in est automatiquement désactivée. Elle peut être réactivée après la fin de l’isolement.
+    checkins_create_qr_code_subtitle: Saisissez un titre qui décrit le lieu ou l’événement. \nCe titre s’affichera lors du check-in.
     checkin_report_heading: Que pouvez-vous faire ?
     checkin_report_title1: Protéger les contacts
     checkin_report_title2: Observer les symptômes
     checkin_report_title3: Se faire tester
     checkin_report_subtitle1: Il est possible d’être contagieux sans le savoir. Respectez les règles d’hygiène et de conduite pour protéger votre famille, vos amis et tout votre entourage.
     checkin_report_subtitle2: Surveillez votre état de santé.
-    checkin_report_subtitle3: Faites-vous immédiatement tester si vous présentez des symptômes. Même en l’absence de symptômes il peut être utile et recommandé de se faire tester pour le coronavirus.
-    meldung_detail_checkin_title: Connexion
+    checkin_report_subtitle3: Faites-vous immédiatement tester si vous présentez des symptômes. Même en l’absence de symptômes, il peut être utile et recommandé de se faire tester pour le coronavirus si vous n'êtes pas encore complètement vacciné.
+    meldung_detail_checkin_title: Check-in
     not_thank_you_screen_title: Pas de données transmises
     not_thank_you_screen_text1: Aucune clé privée n’a été transmise.
     not_thank_you_screen_back_button: Retour
     not_thank_you_screen_dont_send_button: Ne pas transmettre de données
-    not_thank_you_screen_text2: Aucune donnée de connexion n’a été transmise.
+    not_thank_you_screen_text2: Aucune donnée de check-in n’a été transmise.
     inform_share_checkins_send_button_title: Partager la sélection
     inform_share_checkins_not_send_button: Ne rien partager
     onboarding_checkin_title: Se connecter sans enregistrer de données
-    onboarding_checkin_heading: Connexions
-    onboarding_checkin_text1: La fonction de connexion SwissCovid vous permet de vous connecter via l’application dans un lieu particulier ou lors d’une rencontre.
+    onboarding_checkin_heading: Check-ins
+    onboarding_checkin_text1: La fonction de SwissCovid check-in vous permet de vous connecter via l’application dans un lieu particulier ou lors d’une rencontre.
     onboarding_checkin_text2: Votre présence est seulement enregistrée dans votre application. Il n’est pas nécessaire de saisir vos coordonnées dans l’application.
-    checkin_updateboarding_text: La fonction de connexion SwissCovid vous permet de vous connecter via l’application dans un lieu particulier ou lors d’une rencontre. Votre présence est seulement enregistrée dans votre application. Il n’est pas nécessaire de saisir vos coordonnées dans l’application. À cette fin, les conditions d’utilisation et la déclaration de protection des données ont été mises à jour.
+    checkin_updateboarding_text: La fonction de SwissCovid check-in vous permet de vous connecter via l’application dans un lieu particulier ou lors d’une rencontre. Votre présence est seulement enregistrée dans votre application. Il n’est pas nécessaire de saisir vos coordonnées dans l’application. À cette fin, les conditions d’utilisation et la déclaration de protection des données ont été mises à jour.
     onboarding_gaen_button_dont_activate: Passer à l'étape suivante 
     remove_diary_warning_hide_text: La donnée codée est enregistrée en arrière-plan dans l’application pendant 14 jours. Ainsi, en cas de possible infection, une notification peut vous être envoyée.
     remove_diary_warning_hide_button: Masquer uniquement
@@ -651,3 +651,19 @@ fr:
     partial_onboarding_done_text: Merci d’aider à endiguer la propagation du coronavirus.
     web_slogan: Information rapide en cas de risque d’infection.
     test_info_url: https://www.bag.admin.ch/bag/fr/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/testen.html
+    checkout_too_long_alert_text: Cette connextion dure au maximum {DURATION}. Veuillez revérifier les informations saisies.
+    accessibility_camera_light_on: Allumer la lampe de poche
+    accessibility_camera_light_off: Éteindre la lampe de poche
+    error_cannot_enter_covidcode_while_checked_in: Vous êtes encore connecté. Veuillez vous déconnecter avant de saisir le code COVID.
+    events_card_title_events_not_empty: Mes codes QR
+    checkout_inverse_time_alert_description: L'heure de déconnextion est antérieure à l'heure de connexion. Veuillez vérifier les informations saisies.
+    update_notification_checkin_feature_title: Nouvelle fonction : connexion
+    update_notification_checkin_feature_text: Merci d'utiliser SwissCovid. La dernière version de l'application vous permet de vous connecter sur place sans devoir laisser de données.
+    diary_current_title: Actuellement
+    ios_snooze_option_30min: Me rappeler (30 min)
+    ios_snooze_option_1h: Me rappeler (1 h)
+    ios_snooze_option_2h: Me rappeler (2 h)
+    ios_notification_checkout_now: Se déconnecter maintenant
+    covid_certificate_alert_text: Veuillez utiliser l'application COVID Certificate pour scanner ce code QR.
+    covid_certificate_open_app: Ouvrir l'application
+    covid_certificate_install_app: Installer l'application

--- a/dpppt-config-backend/src/main/resources/i18n/messages_hr.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_hr.properties
@@ -327,8 +327,8 @@ hr:
     share_app_supertitle: Zajedno…
     share_app_title: Sprečimo širenje infekcije
     share_app_button: Deli aplikaciju
-    share_app_body: Ako što više nas aktivira aplikaciju SwissCovid, moći ćemo pravovremeno da prekinemo lanac širenja infekcije.
-    share_app_message: Ako što više nas aktivira aplikaciju SwissCovid, moći ćemo pravovremeno da prekinemo lanac širenja infekcije.
+    share_app_body: Ako većina vaših kontakata koristi aplikaciju SwissCovid, možete brzo biti obavešteni u slučaju rizika od zaraze.
+    share_app_message: Pomoću aplikacije Swiss Covid svi možemo da pomognemo u suzbijanju širenja virusa korona.
     share_app_url: https://bag-coronavirus.ch/swisscovid-app/#download
     stats_counter: {COUNT} milion
     stats_source_day: Stanje na dan {DAY}
@@ -478,7 +478,7 @@ hr:
     inform_send_thankyou_text_onsetdate: {ONSET_DATE} – danas
     inform_send_thankyou_text_stop_infection_chains: Na taj način pomažete da se upozore drugi o mogućosti zaraze.
     inform_send_thankyou_text_onsetdate_info: Privatni ključevi vaše aplikacije poslati su za sledeći period:
-    android_inform_tracing_enabled_explanation: Prilikom unosa kovid šifre mora se aktivirati praćenje (tracing) kako bi vaši privatni ključevi mogli da se dele.
+    inform_tracing_enabled_explanation: Prilikom unosa kovid šifre mora se aktivirati praćenje (tracing) kako bi vaši privatni ključevi mogli da se dele.
     leitfaden_infopopup_text: Kada pritisnete "{BUTTON_TITLE}" napuštate aplikaciju i dolazite na internet stranicu SwissCovid vodiča. Pri tome se podaci poslednjeg susreta sa mogućim zaražavanjem šalju internet stranici.
     leitfaden_infopopup_title: Informacije iz SwissCovid vodiča
     germany_update_boarding_title: Kompatibilno sa Nemačkom
@@ -501,10 +501,10 @@ hr:
     edit_mode_comment_placeholder: npr. S kim ste bili tamo?
     done_button: Gotovo
     checkin_set_reminder: Podsećanje na prijavu
-    reminder_option_off: Isključeno
+    reminder_option_off: Off
     authenticate_for_diary: Identifikujte se, kako biste pristupili dnevniku
-    reminder_option_hours: časovi {HOURS} h
-    reminder_option_minutes: minute {MINUTES}'
+    reminder_option_hours: {HOURS} h
+    reminder_option_minutes: {MINUTES}'
     qr_scanner_no_camera_permission: Aplikaciji je potreban pristup kameri, da bi se skenirao QR kod.
     diary_title: Moje prijave
     checkin_button_title: Prijava
@@ -515,7 +515,7 @@ hr:
     module_checkins_title: Prijava
     checkin_title: Prijava
     checkins_create_qr_code: Napraviti QR kod
-    events_title: Ponuditi prijave?
+    events_title: Napravite QR kodove
     check_in_now_button_title: Sada se prijaviti
     checkin_reminder_settings_alert_title: Podsećanje nije uspelo da se unese
     checkin_reminder_settings_alert_message: Da biste dobijali podsetnike za odjavu, morate da dozvolite \ "Obaveštenja \" u podešavanjima aplikacije.
@@ -552,7 +552,7 @@ hr:
     checkin_ended_title: Deaktivirano prijavljivanje
     checkin_ended_text: Trenutno nije moguća prijava
     checkin_detail_checked_out_text: Skenirajte SwissCovid-QR kod, kako biste se prijavili na nekoj lokaciji.
-    checkin_detail_diary_text: Ako skenirate Swiss-Covid-QR kod, da biste se prijavili na nekoj lokaciji, ovde se automatski uređuje unos.
+    checkin_detail_diary_text: Ako skenirate SwissCovid-QR kod, da biste se prijavili na nekoj lokaciji, ovde se automatski uređuje unos.
     checkin_checked_in: Prijavljeni ste
     checkout_from_to_date: {DATE1} do {DATE2}
     inform_detail_covidcode_info_button: Više o Covid kodu
@@ -563,7 +563,7 @@ hr:
     module_checkins_description: Skenirajte SwissCovid-QR kod, kako biste se prijavili na nekoj lokaciji.
     inform_share_checkins_title: Deliti unose o prijavama
     inform_share_checkins_subtitle: Kada delite unose prijave, aplikacija može istovremeno da obavesti lica, koja su se prijavila na istoj lokaciji.
-    inform_share_checkins_select_all: Izabrati sve
+    inform_share_checkins_select_all: Izaberite sve što odgovara
     inform_dont_send_button_title: Ne slati
     inform_dont_share_button_title: Ne deliti
     inform_really_not_share_title: Zaista ne deliti?
@@ -574,10 +574,10 @@ hr:
     remove_diary_warning_hide_title: Samo sakriti i nastaviti da budete obaveštavani?
     home_covidcode_card_title: Test pozitivan?
     home_end_isolation_card_text: Kontakte i prijave ponovo aktivirati. 
-    reminder_option_hours_minutes: časovi {HOURS} h minute {MINUTES}'
+    reminder_option_hours_minutes: {HOURS} h {MINUTES}'
     checkin_overview_isolation_text: Ne možete ponovo da se prijavite ako imate pozitivan test.
     events_card_subtitle: Napravite QR kod, pomoću kojeg lica mogu da se prijave na lokaciji.
-    delete_qr_code_dialog: Želite li zaista da izbrišete QR kod? 
+    delete_qr_code_dialog: Želite li zaista da izbrišete QR kod? Štampani QR kodovi ostaju i dalje na snazi.
     self_checkin_button_title: Samostalno prijavljivanje
     checkin_overview_checkins_explanation: Skenirajte SwissCovid-QR kod, kako biste se prijavili na lokaciji.
     checkout_overlapping_alert_title: Nije moguće obezbeđenje
@@ -591,7 +591,7 @@ hr:
     checkin_detail_checked_out_title: Prijaviti se bez ostavljanja podataka
     home_covidcode_card_text: Ovde unesite svoj Covid kod, kako biste upozorili druge.
     home_end_isolation_card_title: Kraj izolacije?
-    events_card_title: Želite da ponudite prijave?
+    events_card_title: Da li želite da napravite QR kodove?
     checkin_footer_title1: Čemu služi funkcija prijave?
     checkin_footer_subtitle1: Funkcija prijave bez unošenja podataka o kontaktima povećava funkcije aplikacije SwissCovid. Pomoću ove funkcije, u slučaju pozitivnog testa, možete ne samo da upozorite bliske kontakte, već i lica koja su se istovremeno prijavila na istom mestu.
     checkin_footer_title2: Nema centralnog čuvanja podataka
@@ -620,7 +620,7 @@ hr:
     checkin_report_title3: Vršiti testiranje
     checkin_report_subtitle1: Mogli biste biti zarazni, a da to ne primetite. Pridržavajte se važećih higijenskih i zaštitnih mera i zaštitite svoju porodicu, prijatelje i okolinu.
     checkin_report_subtitle2: Proveravajte svoje zdravsveno stanje.
-    checkin_report_subtitle3: Odmah se testirajte ako imate simptome. Čak i ako nema simptoma, test korone je važan i  preporučuje se.
+    checkin_report_subtitle3: Odmah se testirajte ako imate simptome. Čak i ako nema simptoma i niste u potpunosti vakcinisani, test korone je važan i  preporučuje se.
     meldung_detail_checkin_title: Prijava
     not_thank_you_screen_title: Podaci nisu poslati
     not_thank_you_screen_text1: Nisu poslati privatni ključevi.
@@ -649,3 +649,19 @@ hr:
     partial_onboarding_done_text: Hvala vam što pomažete u suzbijanju širenja virusa korone.
     web_slogan: Brze informacije u slučaju rizika od zaraze. 
     test_info_url: https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/testen.html
+    checkout_too_long_alert_text: Ova prijava važi maksimalno u trajanju od {DURATION}. Molimo vas da ponovo proverite svoje podatke.
+    accessibility_camera_light_on: Uključiti svetlo
+    accessibility_camera_light_off: Isključiti svetlo
+    error_cannot_enter_covidcode_while_checked_in: Još uvek ste prijavljeni. Molimo odjavite se pre unosa Covid koda.
+    events_card_title_events_not_empty: Moji QR kodovi
+    checkout_inverse_time_alert_description: Odabrano vreme za odjavu nalazi se je pre vremena za prijavu. Molimo vas da ponovo proverite svoje podatke.
+    update_notification_checkin_feature_title: Nova funkcija: prijava
+    update_notification_checkin_feature_text: Hvala vam što koristite SwissCovid. Sa najnovijom verzijom aplikacije možete da se prijavite na lokaciji bez ostavljanja podataka.
+    diary_current_title: Trenutno
+    ios_snooze_option_30min: Podsetiti ponovo (30min)
+    ios_snooze_option_1h: Podsetiti ponovo (1h)
+    ios_snooze_option_2h: Podsetiti ponovo (2h)
+    ios_notification_checkout_now: Sada se odjaviti
+    covid_certificate_alert_text: Molimo koristite aplikaciju "COVID certifikat" za skeniranje ovog QR koda.
+    covid_certificate_open_app: Otvoriti aplikaciju
+    covid_certificate_install_app: Instalirati aplikaciju

--- a/dpppt-config-backend/src/main/resources/i18n/messages_it.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_it.properties
@@ -311,7 +311,7 @@ it:
     travel_title: Viaggi
     travel_home_description: L'app SwissCovid funziona nei seguenti Paesi:
     travel_screen_explanation_title_1: Cosa significa?
-    travel_screen_explanation_text_1: Se ti trovi in un Paese compatibile non devi installare una nuova app di tracciamento.\n\nL'app SwissCovid verifica le chiavi private pubblicate nei Paesi compatibili. In questo modo ti può avvisare anche in caso di possibile contagio all'estero.
+    travel_screen_explanation_text_1: Se ti trovi in un Paese compatibile non devi installare una nuova app di tracciamento per gli incontri.\n\nL'app SwissCovid verifica le chiavi private pubblicate nei Paesi compatibili. In questo modo ti può avvisare anche in caso di possibile contagio all'estero.
     travel_screen_explanation_title_2: Cosa succede immettendo un codice Covid?
     travel_screen_explanation_text_2: Dopo che il codice Covid è stato inserito, l'app condivide le chiavi private da te trasmesse anche con i Paesi compatibili.\n\nAffinché anche i viaggiatori all'estero possano essere avvisati, la condivisione avviene a prescindere dal fatto che tu sia stato all'estero o meno.
     accessibility_faq_button_hint_non_bag: Questo pulsante permette di lasciare l'app e di aprire un sito Internet.
@@ -328,8 +328,8 @@ it:
     share_app_supertitle: Insieme…
     share_app_title: impediamo i contagi
     share_app_button: Condividi l'app
-    share_app_body: Quante più persone attivano l'app SwissCovid, tanto più è possibile interrompere precocemente le catene di infezione.
-    share_app_message: Quante più persone attivano l'app SwissCovid, tanto più è possibile interrompere precocemente le catene di infezione.
+    share_app_body: Se il maggior numero possibile dei tuoi contatti utilizza l'app SwisCovid, in caso di rischio di contagio puoi essere informato rapidamente.
+    share_app_message: Con l'app SwissCovid tutti possono contribuire a contenere la diffusione del coronavirus.
     share_app_url: https://ufsp-coronavirus.ch/app-swisscovid/#download
     stats_counter: {COUNT} mio.
     stats_source_day: Stato dei dati {DAY}
@@ -469,7 +469,7 @@ it:
     homescreen_isolation_ended_popup_text: Il tracciamento può essere riattivato non appena l'isolamento è concluso.
     answer_yes: Sì
     answer_no: No
-    travel_screen_info: Vi trovate all'estero? L'app SwissCovid funziona nei seguenti Paesi.
+    travel_screen_info: Ti trovi all'estero? L'app SwissCovid funziona nei seguenti Paesi per gli incontri.
     travel_screen_compatible_countries: Paesi compatibili:
     inform_code_travel_text: Affinché anche i viaggiatori provenienti dall'estero possano essere avvisati dopo un incontro, le chiavi private vengono condivise con le app di tracciamento dei Paesi compatibili.
     stats_covidcodes_total_header: Totale
@@ -480,7 +480,7 @@ it:
     inform_send_thankyou_text_onsetdate: {ONSET_DATE} – oggi
     inform_send_thankyou_text_stop_infection_chains: Così contribuisci ad avvisare gli altri di un possibile contagio.
     inform_send_thankyou_text_onsetdate_info: Le chiavi private della tua app sono state inviate per il seguente periodo:
-    android_inform_tracing_enabled_explanation: Al momento dell'immissione di un codice Covid il tracciamento deve essere attivato affinché sia possibile condividere le tue chiavi private.
+    inform_tracing_enabled_explanation: Al momento dell'immissione di un codice Covid il tracciamento deve essere attivato affinché sia possibile condividere le tue chiavi private.
     leitfaden_infopopup_text: Premendo il pulsante "{BUTTON_TITLE}" si esce dall'app e si passa al sito web della guida SwissCovid. I dati degli ultimi incontri con persone potenzialmente infette vengono trasmessi al sito web.
     leitfaden_infopopup_title: Informazioni sulla guida SwissCovid
     germany_update_boarding_title: Compatibile con la Germania
@@ -503,7 +503,7 @@ it:
     edit_mode_comment_placeholder: p. es. con chi eri?
     done_button: Fatto
     checkin_set_reminder: Promemoria check-out
-    reminder_option_off: Disattiva
+    reminder_option_off: Off
     authenticate_for_diary: Autenticati per accedere al diario
     reminder_option_hours: {HOURS} h
     reminder_option_minutes: {MINUTES}'
@@ -517,7 +517,7 @@ it:
     module_checkins_title: Check-in
     checkin_title: Check-in
     checkins_create_qr_code: Crea codice QR
-    events_title: Offrire i check-in?
+    events_title: Creare codici QR
     check_in_now_button_title: Fai il check-in ora
     checkin_reminder_settings_alert_title: Impossibile impostare il promemoria
     checkin_reminder_settings_alert_message: Per ricevere i promemoria check-out devi consentire le \"notifiche\" nelle impostazioni dell'app.
@@ -565,7 +565,7 @@ it:
     module_checkins_description: Scansiona un codice QR SwissCovid per fare il check-in sul posto.
     inform_share_checkins_title: Condividi le voci di check-in
     inform_share_checkins_subtitle: Se condividi le tue voci di check-in, l'app potrà informare le persone che hanno fatto il check-in nello stesso luogo e nello stesso momento.
-    inform_share_checkins_select_all: Seleziona tutto
+    inform_share_checkins_select_all: Seleziona tutti quelli adatti
     inform_dont_send_button_title: Non inviare
     inform_dont_share_button_title: Non condividere
     inform_really_not_share_title: Non condividere?
@@ -578,8 +578,8 @@ it:
     home_end_isolation_card_text: Riattiva gli incontri e il check-in
     reminder_option_hours_minutes: {HOURS} h {MINUTES}'
     checkin_overview_isolation_text: Se sei risultato positivo al test, non puoi più fare il check-in.
-    events_card_subtitle: Crea un codice QR per consentire alle persone di fare il check-in sul posto
-    delete_qr_code_dialog: Eliminare il codice QR?
+    events_card_subtitle: Crea un codice QR SwissCovid con il quale le persone possono fare il check-in sul posto
+    delete_qr_code_dialog: Eliminare il codice QR? I codici QR stampati restano validi.
     self_checkin_button_title: Self check-in
     checkin_overview_checkins_explanation: Scansiona un codice QR SwissCovid per fare il check-in sul posto.
     checkout_overlapping_alert_title: Impossibile salvare
@@ -593,7 +593,7 @@ it:
     checkin_detail_checked_out_title: Check-in\nsenza lasciare dati
     home_covidcode_card_text: Immetti il codice Covid per avvisare gli altri
     home_end_isolation_card_title: Terminare l'isolamento?
-    events_card_title: Vuoi offrire i check-in?
+    events_card_title: Creare codici QR?
     checkin_footer_title1: Perché una funzione check-in?
     checkin_footer_subtitle1: La funzione check-in senza registrazione dei dati di contatto completa l'app SwissCovid. Con questa funzione, in caso di test positivo puoi avvisare non solo i contatti stretti, ma anche le persone che hanno fatto il check-in nello stesso luogo e nello stesso momento.
     checkin_footer_title2: Nessun salvataggio centralizzato dei dati
@@ -622,7 +622,7 @@ it:
     checkin_report_title3: Fai il test
     checkin_report_subtitle1: Potresti già essere contagioso senza accorgertene. Rispetta le misure d'igiene e di protezione vigenti e proteggi la tua famiglia, i tuoi amici e il tuo ambiente.
     checkin_report_subtitle2: Sorveglia il tuo stato di salute.
-    checkin_report_subtitle3: In caso di sintomi fai subito il test. Il test è raccomandato anche in assenza di stintomi.
+    checkin_report_subtitle3: In caso di sintomi fai subito il test. Per chi non è ancora completamente vaccinato, il test è opportuno e raccomandato anche in assenza di sintomi.
     meldung_detail_checkin_title: Check-in
     not_thank_you_screen_title: Nessun dato inviato
     not_thank_you_screen_text1: Nessuna chiave privata inviata
@@ -651,3 +651,19 @@ it:
     partial_onboarding_done_text: Grazie per aiutarci a contenere la diffusione del coronavirus.
     web_slogan: Informazione rapida in caso di rischio di contagio
     test_info_url: https://www.bag.admin.ch/bag/it/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/testen.html
+    checkout_too_long_alert_text: Per questo check-in vige una durata massima di {DURATION}. Controlla il dato immesso.
+    accessibility_camera_light_on: Accendi la torcia
+    accessibility_camera_light_off: Spegni la torcia
+    error_cannot_enter_covidcode_while_checked_in: Il tuo check-in è ancora attivo. Fai il check-out prima di immettere il codice COVID.
+    events_card_title_events_not_empty: I miei codici QR
+    checkout_inverse_time_alert_description: L'orario di check-out che hai selezionato è anteriore all'orario di check-in. Controlla il dato immesso.
+    update_notification_checkin_feature_title: Nuova funzione: check-in
+    update_notification_checkin_feature_text: Grazie per utilizzare l'app SwissCovid. Con la versione più recente dell'app puoi fare il check-in sul posto senza lasciare dati.
+    diary_current_title: Attuali
+    ios_snooze_option_30min: Ricordamelo più tardi (30min)
+    ios_snooze_option_1h: Ricordamelo più tardi (1h)
+    ios_snooze_option_2h: Ricordamelo più tardi (2h)
+    ios_notification_checkout_now: Fai il check-out
+    covid_certificate_alert_text: Utilizza l'app "Covid Certificate" per scansionare questo codice QR.
+    covid_certificate_open_app: Apri l'app
+    covid_certificate_install_app: Installa l'app

--- a/dpppt-config-backend/src/main/resources/i18n/messages_pt.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_pt.properties
@@ -311,7 +311,7 @@ pt:
     travel_title: Viajar
     travel_home_description: O SwissCovid-Contactos funciona nos seguintes países:
     travel_screen_explanation_title_1: O que significa isto?
-    travel_screen_explanation_text_1: Se viajar para um dos países compatíveis, não necessita de instalar mais nenhum app de coronavírus.\n\nA SwissCovid verifica as chaves privadas divulgadas nos países compatíveis para que possa ser alertado de um possível contágio, mesmo no estrangeiro.
+    travel_screen_explanation_text_1: Se viajar para um dos países compatíveis, não necessita de instalar mais nenhum aplicativo de coronavírus.\n\nO SwissCovid verifica as chaves privadas divulgadas nos países compatíveis para que possa ser alertado dum possível contágio, mesmo no estrangeiro.
     travel_screen_explanation_title_2: O que acontece quando insiro o código COVID?
     travel_screen_explanation_text_2: Ao inserir o código COVID, as chaves privadas que enviou também serão partilhadas com os países compatíveis.\n\nIsto acontece independentemente de ter estado no estrangeiro ou não para que os viajantes estrangeiros possam também ser alertados.
     accessibility_faq_button_hint_non_bag: Este botão permite sair da aplicação e abrir uma página de internet.
@@ -328,8 +328,8 @@ pt:
     share_app_supertitle: Juntos…
     share_app_title: prevenimos o contágio 
     share_app_button: Partilhar a app
-    share_app_body: Quanto mais pessoas ativarem a app SwissCovid, mais cedo conseguiremos interromper as cadeias de transmissão.
-    share_app_message: Quanto mais pessoas ativarem a app SwissCovid, mais cedo conseguiremos interromper as cadeias de transmissão.
+    share_app_body: Se o maior número possível dos seus contactos usar o aplicativo SwissCovid, você pode ser informado rapidamente em caso de risco de contágio.
+    share_app_message: Com a app Swiss Covid, todos podem ajudar a conter a propagação do coronavírus.
     share_app_url: https://bag-coronavirus.ch/swisscovid-app/#download
     stats_counter: {COUNT} milhões
     stats_source_day: Última atualização dos dados {DAY}
@@ -469,7 +469,7 @@ pt:
     homescreen_isolation_ended_popup_text: O rastreamento pode ser reativado logo que termine o isolamento.
     answer_yes: Sim
     answer_no: Não
-    travel_screen_info: Está no estrangeiro? A SwissCovid funciona nestes países.
+    travel_screen_info: Está no estrangeiro? O SwissCovid funciona nestes países.
     travel_screen_compatible_countries: Países compatíveis:
     inform_code_travel_text: Para alertar também os viajantes de outros países, as chaves privadas são partilhadas com os aplicativos de coronavírus dos países compatíveis.
     stats_covidcodes_total_header: Total
@@ -480,7 +480,7 @@ pt:
     inform_send_thankyou_text_onsetdate: {ONSET_DATE} – hoje
     inform_send_thankyou_text_stop_infection_chains: Com isso, você pode ajudar a alertar outros sobre um eventual contágio.
     inform_send_thankyou_text_onsetdate_info: Os códigos privados do seu aplicativo foram enviados para o seguinte período:
-    android_inform_tracing_enabled_explanation: Ao introduzir um código Covid, o rastreamento deve estar ativado para que seja possível compartilhar os seus códigos privados.
+    inform_tracing_enabled_explanation: Ao introduzir um código Covid, o rastreamento deve estar ativado para que seja possível compartilhar os seus códigos privados.
     leitfaden_infopopup_text: Ao premir "{BUTTON_TITLE}" você sai do aplicativo e vai para o website do Guia SwissCovid. Nisso, os dados dos últimos encontros com possibilidade de infecção do website também são enviados.
     leitfaden_infopopup_title: Informação Guia SwissCovid
     germany_update_boarding_title: Compatível com a Alemanha
@@ -502,7 +502,7 @@ pt:
     edit_mode_comment_placeholder: p. ex. Com quem você esteve lá?
     done_button: Pronto
     checkin_set_reminder: Lembrete de checkout
-    reminder_option_off: Desligado
+    reminder_option_off: Off
     authenticate_for_diary: Autentique-se para ter acesso ao diário
     reminder_option_hours: {HOURS} h
     reminder_option_minutes: {MINUTES}'
@@ -516,7 +516,7 @@ pt:
     module_checkins_title: Check-in
     checkin_title: Check-in
     checkins_create_qr_code: Criar um código QR
-    events_title: Oferecer check-ins?
+    events_title: Gerar códigos QR
     check_in_now_button_title: Fazer check-in agora
     checkin_reminder_settings_alert_title: Não foi possível enviar o lembrete
     checkin_reminder_settings_alert_message: Para receber lembretes de check-out, é necessário permitir as \"notificações\" na configuração do aplicativo.
@@ -564,7 +564,7 @@ pt:
     module_checkins_description: Leia um código QR SwissCovid para fazer check-in no local.
     inform_share_checkins_title: Compartilhar registos de check-in
     inform_share_checkins_subtitle: Se compartilhar os seus registos de check-in, o aplicativo pode informar pessoas que fizeram check-in no mesmo lugar e na mesma altura.
-    inform_share_checkins_select_all: Selecionar todos
+    inform_share_checkins_select_all: Selecionar todos os correspondentes
     inform_dont_send_button_title: Não enviar
     inform_dont_share_button_title: Não compartilhar
     inform_really_not_share_title: Realmente não deseja compartilhar?
@@ -578,7 +578,7 @@ pt:
     reminder_option_hours_minutes: {HOURS} h {MINUTES}'
     checkin_overview_isolation_text: Você não pode mais fazer check-in depois de ser testado positivo.
     events_card_subtitle: Gere um código QR com o qual pessoas podem fazer check-in no local.
-    delete_qr_code_dialog: Realmente deseja apagar o código QR?
+    delete_qr_code_dialog: Realmente deseja apagar o código QR? Os códigos QR impressos continuam válidos.
     self_checkin_button_title: Check-in próprio
     checkin_overview_checkins_explanation: Leia um código QR SwissCovid para fazer check-in no local.
     checkout_overlapping_alert_title: Não é possível salvar
@@ -591,7 +591,7 @@ pt:
     pdf_download_app: Baixar agora
     checkin_detail_checked_out_title: Fazer check-in sem deixar dados
     home_covidcode_card_text: Introduza o seu código Covid aqui para alertar outras pessoas.
-    events_card_title: Terminar o isolamento?
+    events_card_title: Deseja gerar códigos QR?
     checkin_footer_title1: Porque uma função de check-in?
     checkin_footer_subtitle1: A função de check-in sem recolha de dados de contacto amplia o aplicativo SwissCovid. Com esta função você pode não só alertar contactos próximos, mas também pessoas que fizeram check-in no mesmo lugar e na mesma altura, em caso de teste positivo.
     checkin_footer_title2: Nenhum armazenamento de dados centralizado
@@ -620,7 +620,7 @@ pt:
     checkin_report_title3: Deixar testar-se
     checkin_report_subtitle1: Você já pode ser contagioso, sem percebê-lo. Observe as medidas de higiene e proteção vigentes e proteja a sua família, os amigos e o seu ambiente.
     checkin_report_subtitle2: Observe o seu estado de saúde.
-    checkin_report_subtitle3: Deixe testar-se imediatamente se aparecerem sintomas. Mesmo se não aparecerem sintomas, um teste de corona é conveniente e recomendado.
+    checkin_report_subtitle3: Deixe testar-se imediatamente se aparecerem sintomas. Mesmo se não aparecerem sintomas e se você ainda não tiver sido completamente vacinado, um teste de corona é conveniente e recomendado.
     meldung_detail_checkin_title: Check-in
     not_thank_you_screen_title: Não foram enviados dados.
     not_thank_you_screen_text1: Não foram enviadas chaves privadas.
@@ -649,3 +649,19 @@ pt:
     partial_onboarding_done_text: Agradecemos a sua ajuda para conter a propagação do coronavírus.
     web_slogan: Informação rápida em caso de risco de infeção
     test_info_url: https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/testen.html
+    checkout_too_long_alert_text: A este check-in aplica-se uma duração máxima de check-in de {DURATION}. Por favor, verifique a sua introdução.
+    accessibility_camera_light_on: Acender a luz
+    accessibility_camera_light_off: Apagar a luz
+    error_cannot_enter_covidcode_while_checked_in: Você ainda não fez check-out. Por favor, faça check-out antes de introduzir o código Covid.
+    events_card_title_events_not_empty: Meus códigos QR
+    checkout_inverse_time_alert_description: A sua hora de check-out selecionada é antes da sua hora de check-in. Por favor, verifique a sua introdução.
+    update_notification_checkin_feature_title: Nova função: Check-in
+    update_notification_checkin_feature_text: Agradecemos a utilização do SwissCovid. Com a última versão do aplicativo você pode fazer check-in no local sem deixar dados.
+    diary_current_title: Atual
+    ios_snooze_option_30min: Lembrar novamente (30min)
+    ios_snooze_option_1h: Lembrar novamente (1h)
+    ios_snooze_option_2h: Lembrar novamente (2h)
+    ios_notification_checkout_now: Fazer check-out agora
+    covid_certificate_alert_text: Por favor, use o aplicativo "Certificado COVID" para ler este código QR.
+    covid_certificate_open_app: Abrir o aplicativo
+    covid_certificate_install_app: Instalar o aplicativo

--- a/dpppt-config-backend/src/main/resources/i18n/messages_rm.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_rm.properties
@@ -32,7 +32,7 @@ rm:
     push_deactivated_title: Deactivà communicaziuns
     push_deactivated_text: Midai la configuraziun per che Vus vegnias infurmada/infurmà directamain en cas d’in avis.
     meldungen_meldung_title: Eventuala infecziun
-    meldungen_meldung_text: Ina infecziun è pussaivla.
+    meldungen_meldung_text: Igl è pussaivel che Vus essas As infectada/infectà.
     tracing_active_title: App activa
     tracing_active_text: Inscunters vegnan arcunads en moda anonima
     android_tracing_error_title: Tracing inactiv
@@ -62,7 +62,7 @@ rm:
     inform_detail_subtitle: Tge far en cas d'in…
     inform_detail_title: test positiv?
     inform_detail_box_subtitle: Cun il code covid...
-    inform_detail_box_title: Franar chadainas d'infecziun
+    inform_detail_box_title: Avertir en cas d'ina eventuala infecziun
     inform_detail_box_button: Endatar il code covid
     inform_detail_box_text: Cun endatar il code covid communitgais Vus a l'app che Vus essas testada/testà en moda positiva sin il nov coronavirus
     symptom_detail_subtitle: Tge far, sche jau…
@@ -75,8 +75,8 @@ rm:
     symptom_detail_navigation_title: Sintoms
     tracing_turned_off_title: Tracing deactivà
     tracing_turned_off_text: Activai il tracing per far funcziunar l'app.
-    bluetooth_turned_off_title: Bluetooth off
-    bluetooth_turned_off_text: Activai bluetooth sin Voss apparat per far funcziunar il tracing.
+    bluetooth_turned_off_title: Deactivà Bluetooth
+    bluetooth_turned_off_text: Activai Bluetooth sin Voss apparat per ch'il tracing anonim funcziunia.
     bluetooth_turn_on_button_title: Activar bluetooth
     bluetooth_permission_error_title: Refusà l’activaziun bluetooth
     bluetooth_permission_error_text: Permettai l’activaziun da bluetooth per far funcziunar il tracing.
@@ -90,15 +90,15 @@ rm:
     meldung_detail_positive_test_box_subtitle: Tge duai jau far?
     meldung_detail_positive_test_box_title: Isolaziun
     meldung_detail_positive_test_box_text: Observai las instrucziuns davart l'isolaziun che Vus avais retschavì
-    tracing_ended_title: Tracing terminà
-    tracing_ended_text: I na vegnan arcunads pli nagins inscunters.
+    tracing_ended_title: Deactivà inscunters e registraziuns
+    tracing_ended_text: I na vegnan arcunads nagins inscunters
     exposed_info_contact_hotline: Contactai la
     meldung_homescreen_positive_info_line1: Observai la
-    meldung_homescreen_positive_info_line2: Instrucziuns davart l'autoisolaziun
+    meldung_homescreen_positive_info_line2: Instrucziuns davart l'isolaziun
     meldung_detail_exposed_new_meldung: Nov avis
     meldung_detail_exposed_title: Eventuala infecziun
     meldung_homescreen_positiv_title: Testada/testà en moda positiva
-    meldung_detail_exposed_subtitle: Ina infecziun è pussaivla.
+    meldung_detail_exposed_subtitle: Igl è pussaivel che Vus essas As infectada/infectà.
     meldung_homescreen_positiv_text: Vus essas vegnida testada/vegnì testà en moda positiva sin il coronavirus.
     reset_onboarding: Redefinir onboarding
     date_today: Oz
@@ -116,18 +116,18 @@ rm:
     onboarding_prinzip_heading: La finamira
     onboarding_prinzip_title: In pass ordavant al virus
     onboarding_prinzip_text1: Cun l'app SwissCovid pon tuts gidar da franar la derasaziun dal coronavirus.
-    onboarding_prinzip_text2: L'app As infurmescha, sche Vus essas stada exponida/stà exponì al coronavirus.
+    onboarding_prinzip_text2: L'app As avertescha, sche Vus essas stada exponida/stà exponì potenzialmain al coronavirus.
     onboarding_privacy_heading: Privacy by Design
     onboarding_privacy_title: Protecziun da la sfera privata
     onboarding_privacy_text1: Tranter ils telefons mobils vegnan barattadas mo IDs casualas. L'app na rimna ni datas davart la posiziun ni datas davart Vossa identitad.
     onboarding_privacy_text2: Las IDs casualas arcunadas restan sin Voss telefon mobil e vegnan stizzadas suenter 14 dis.
-    onboarding_begegnungen_heading: Co funcziuna l'app?
+    onboarding_begegnungen_heading: Inscunters
     onboarding_begegnungen_title: Identifitgar inscunters grazia a bluetooth
     onboarding_begegnungen_text1: L'app percorscha automaticamain, sche dus utilisaders èn damanaivel in da l’auter per in tschert temp.
     onboarding_begegnungen_text2: Per quest intent vegni duvrà mo Bluetooth Low Energy (BLE). Naginas datas da GPS, da telefon mobil, da WiFi u autras datas da posiziun.
     onboarding_meldung_heading: Tge fa l'app?
     onboarding_meldung_title: Avis en cas d'ina eventuala infecziun
-    onboarding_meldung_text1: L'app As infurmescha, sche Vus essas stada exponida/stà exponì potenzialmain al coronavirus.
+    onboarding_meldung_text1: L'app As avertescha, sche Vus essas stada exponida/stà exponì potenzialmain al coronavirus.
     onboarding_meldung_text2: Cun il cumportament gist pudais Vus interrumper chadainas d'infecziun e proteger autras persunas.
     onboarding_bluetooth_title: Permetter bluetooth
     onboarding_bluetooth_text: Per pudair duvrar l'app stuais Vus permetter bluetooth.
@@ -138,14 +138,14 @@ rm:
     onboarding_bluetooth_gtk_title2: Diever levamain augmentà da la battaria 
     onboarding_bluetooth_gtk_text2: L'app è realisada uschia ch'ella spargna energia il meglier pussaivel. Il diever da la battaria s'augmenta mo levamain.
     onboarding_push_title: Permetter communicaziuns
-    onboarding_push_text: Per vegnir infurmada/infurmà da l'app stuais Vus permetter communicaziuns.
+    onboarding_push_text: Per che l'app possia avertir Vus, stuais Vus permetter messadis.
     onboarding_push_button: Permetter communicaziuns
     onboarding_push_gtk_title1: Infurmada/infurmà immediatamain
     onboarding_push_gtk_text1: En cas d'ina eventuala infecziun vegnis Vus infurmada/infurmà cun ina communicaziun sin il visur bloccà.
     inform_send_getwell_title: Bun meglierament
     inform_send_getwell_text: Vegni svelt puspè sauna/saun.\n\nResguardai las directivas davart l'isolaziun che Vus avais retschavì.
     onboarding_go_title: L'app è installada
-    onboarding_go_text: Grazia fitg che Vus gidais d'interrumper chadainas d'infecziun.
+    onboarding_go_text: Grazia fitg che Vus gidais a franar la derasaziun dal coronavirus.
     onboarding_go_button: Cumenzar
     homescreen_meldung_data_outdated_title: Naginas datas actualas
     homescreen_meldung_data_outdated_text: Dapi intgin temp n'han ils avis betg pudì vegnir sincronisads. Verifitgai che Voss telefon mobil saja connectà cun l'internet.
@@ -154,7 +154,7 @@ rm:
     inform_code_invalid_subtitle: En cas da problems: telefonai per plaschair al post che ha dà a Vus il code covid.
     date_one_day_ago: avant 1 di
     meldung_detail_new_contact_title: Nov suspect
-    meldung_detail_new_contact_subtitle: Ina infecziun è pussaivla.
+    meldung_detail_new_contact_subtitle: Igl è pussaivel che Vus essas As infectada/infectà.
     time_inconsistency_title: Sbagl ura
     time_inconsistency_text: L'ura sto esser drizzada en moda correcta per ch'il tracing possia funcziunar.
     begegnungen_restart_error_title: Reinizialisaziun necessaria
@@ -198,7 +198,7 @@ rm:
     begegnungen_detail_faq3_text: Bluetooth sto adina esser activà per che las scuntradas possian vegnir identifitgadas.\n\nll diever da la battaria s'augmenta qua tras mo levamain.
     faq_button_title: Dumondas frequentas
     meldungen_nomeldungen_faq1_title: Tge èn avis?
-    meldungen_nomeldungen_faq1_text: L'app verifitgescha regularmain, sche autras utilisadras ed auters utilisaders che Vus avais scuntrà han annunzià in test positiv.\n\nEn cas d'ina eventuala infecziun vegnis Vus orientada/orientà cun ina communicaziun sin il visur bloccà.
+    meldungen_nomeldungen_faq1_text: L'app controllescha regularmain, sche autras utilisadras ed auters utilisaders che Vus avais inscuntrà u ch'èn stads registrads en il medem lieu han annunzià in test positiv.\n\nEn cas d'ina eventuala infecziun, As infurmescha in messadi sin il visur bloccà.
     meldungen_detail_explanation_text3: L'infoline SwissCovid As cusseglia davart la pussaivladad d'in test gratuit.
     meldungen_meldungen_faq1_title: Stoss jau telefonar?
     meldungen_meldungen_faq1_text: Igl è recumandà da telefonar tar mintga nov avis.                                                                                                                                                   \n\nVus restais anonima/anonim. I na vegnan registradas naginas datas persunalas.\n\nIl discurs da cussegliaziun è gratuit; igl è da pajar mo la taxa da telefon.
@@ -209,16 +209,16 @@ rm:
     inform_detail_faq1_title: Tge è in code covid?
     inform_detail_faq1_text: Persunas cun in test positiv sin il coronavirus (test da PCR u test svelt d'antigens) retschaivan in code covid.\n\nUschia vegn garantì ch'i vegnian annunziads sur l'app mo ils cas confermads.
     inform_detail_faq2_title: Tge vegn tramess?
-    inform_detail_faq2_text: I vegnan tramessas mo las clavs privatas da Vossa app, naginas datas persunalas.\n\nUschia vegnan autras utilisadras ed auters utilisaders da l'app SwissCovid a savair ch'ina infecziun è pussaivla.
+    inform_detail_faq2_text: I vegnan tramessas mo las clavs privatas da Vossa app e las IDs codadas da Vossas registraziuns, naginas datas persunalas.\n\nUschia vegnan autras utilisadras ed auters utilisaders da l'app SwissCovid a savair ch’ellas u els èn eventualmain s’infectadas/s’infectads.
     infoline_tel_number: +41 58 387 77 78
     faq_button_url: https://www.bag.admin.ch/bag/de/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/faq-kontakte-downloads/haeufig-gestellte-fragen.html?faq-url=/de/categories/swisscovid-app
-    inform_code_intro_title: Infurmaziun impurtanta
-    inform_code_intro_text: Cumbain ch'i na vegnan tramessas naginas datas davart Vossa persuna, èsi pussaivel ch'insatgi sa regorda da l'inscunter a maun da la data.
+    inform_code_intro_title: Infurmaziun davart l'endataziun
+    inform_code_intro_text: Malgrà ch'i na vegnan tramessas naginas datas persunalas, èsi pussaivel ch'insatgi sa regorda – a maun da la data – da l'inscunter cun Vus.
     inform_code_intro_button: D'accord
     symptom_faq1_title: Tge èn sintoms da COVID-19?
     symptom_faq1_text: Quests sintoms cumparan savens:\n\n– fevra, sentiment da fevra\n– mal la gula\n– tuss (per il solit tuss sitga)\n– respiraziun asmatica\n– mal il pèz\n– perdita andetga da l'odurat e/u dal palat\n\nPussaivels èn er ils suandants sintoms:\n\n– mal il chau\n– deblezza generala, malesser\n– mal ils musculs\n– dafraid\n– sintoms dal tract digestiv (indispostadad, vomitar, diarrea, mal il venter)\n– eczems
     meldungen_positive_tested_faq1_title: Pertge è il tracing deactivà?
-    meldungen_positive_tested_faq1_text: Suenter in test positiv vegn il tracing deactivà automaticamain en l'app. Il tracing po puspè vegnir activà, uschespert che Vus avais terminà l'isolaziun.
+    meldungen_positive_tested_faq1_text: Suenter in test positiv vegn il tracing en l'app deactivà automaticamain. Il tracing po puspè vegnir activà, uschespert che Vus avais terminà l'isolaziun.
     language_key: rm
     exposed_info_contact_hotline_name: Infoline SwissCovid
     date_in_one_day: Anc 1 di
@@ -231,7 +231,7 @@ rm:
     accessibility_code_input_hint: Tippar duas giadas per modifitgar
     accessibility_faq_button_hint: Quest button banduna l'app ed avra la pagina d'internet da U.F.S.P.
     onboarding_gaen_title: Activar tracing
-    onboarding_gaen_text_ios: Per pudair utilisar l'app, ston vegnir activadas communicaziuns da contact COVID-19.
+    onboarding_gaen_text_ios: Per pudair identifitgar inscunters èsi necessari d'activar la funcziun da tracing.
     onboarding_gaen_button_activate: Activar
     onboarding_gaen_info_title_1: Protecziun da datas
     onboarding_gaen_info_text_1: I vegnan barattadas mo IDs casualas. Naginas datas davart la posiziun u davart Vossa persuna.
@@ -243,7 +243,7 @@ rm:
     delete_infection_button: Terminar l'isolaziun
     delete_infection_dialog: Vulais Vus propi stizzar l’avis?
     android_onboarding_battery_permission_title: Ignorar l'optimaziun da l'accu
-    android_onboarding_battery_permission_text: Per pudair identifitgar ils inscunters d’in cuntin, sto l'optimaziun da l'accu esser deactivada per questa app.
+    android_onboarding_battery_permission_text: Per che l'app funcziunia sto l'optimaziun da l'accu esser deactivada.
     android_onboarding_battery_permission_button: Permetter
     android_onboarding_battery_permission_button_deactivated: OK
     android_onboarding_battery_permission_info_1_title: Mo per questa app
@@ -255,7 +255,7 @@ rm:
     gaen_not_available_text: Activai per plaschair Voss Google Play Services
     gaen_unexpectedly_disabled: Tracing è vegnì deactivà. Per plaschair reinizialisar il tracing.
     tracing_permission_error_title_ios: Deactivà communicaziuns da contact COVID-19 
-    tracing_permission_error_text_ios: Activai communicaziuns da contact COVID-19 per ch'il tracing funcziunia.
+    tracing_permission_error_text_ios: Activai {TRACING_SETTING_TEXT} per ch'il tracing anonim funcziunia.
     user_cancelled_key_sharing_error: La communicaziun n'ha betg pudì vegnir tramessa. Permettai per plaschair da cundivider Vossas IDs casualas cun l'app SwissCovid.
     playservices_update: Actualisar
     playservices_install: Installar
@@ -275,12 +275,12 @@ rm:
     synchronizations_view_period_title: Durant ils ultims 14 dis
     synchronizations_view_empty_list: Naginas endataziuns
     tracing_active_tracking_always_info: SwissCovid resta activ, er sche l'app vegn serrada.
-    oboarding_splashscreen_title: SwissCovid \nfraina \nchadainas d'infecziun.\n
-    inform_detail_faq3_text: Cumbain ch'i na vegnan tramessas naginas datas davart Vossa persuna, èsi pussaivel ch'insatgi sa regorda da l'inscunter a maun da la data.
+    oboarding_splashscreen_title: SwissCovid –\ninfurmescha svelt en cas d'ina ristga d'infecziun.\n
+    inform_detail_faq3_text: Malgrà ch'i na vegnan tramessas naginas datas persunalas, èsi pussaivel ch'insatgi sa regordav– a maun da la data – da l'inscunter cun Vus.
     inform_detail_faq3_title: Rest jau anonima/anonim?
     meldungen_detail_explanation_text4: En cas d'emprims sintoms contactai ina media resp. in medi u ina instituziun da sanadad.
     tracing_setting_text_android: Communicaziuns COVID-19
-    onboarding_gaen_text_android: Per pudair utilisar l'app, ston vegnir activadas communicaziuns COVID-19
+    onboarding_gaen_text_android: Per pudair identifitgar inscunters sto vegnir activada la funcziun da tracing.
     onboarding_disclaimer_heading: SwissCovid
     onboarding_disclaimer_title: Infurmaziuns davart il diever
     onboarding_disclaimer_info: Legiai per plaschair la decleraziun davart la protecziun da datas e las cundiziuns d’utilisaziun.
@@ -309,9 +309,9 @@ rm:
     meldungen_tracing_turned_off_warning: Sch'il tracing è deactivà, na pon er vegnir retschavids nagins avis.
     infobox_close_button_accessibility: Serrar
     travel_title: Viadis
-    travel_home_description: SwissCovid funcziuna en ils suandants pajais:
+    travel_home_description: Inscunters SwissCovid funcziuna en ils suandants pajais:
     travel_screen_explanation_title_1: Tge vul quai dir?
-    travel_screen_explanation_text_1: Sche Vus essas (en gir) en in pajais cumpatibel, na stuais Vus betg installar in'autra app da corona.\n\nSwissCovid verifitgescha las clavs privatas ch'èn vegnidas publitgadas en ils pajais cumpatibels. Uschia pudais Vus vegnir infurmada resp. infurmà er en cas d'ina eventuala infecziun a l'exteriur.
+    travel_screen_explanation_text_1: Sche Vus essas en in pajais cumpatibel, na stuais Vus betg installar in'autra app da corona.\n\nSwissCovid verifitgescha las clavs privatas ch'èn vegnidas publitgadas en ils pajais cumpatibels. Uschia pudais Vus vegnir infurmada resp. infurmà er en cas d'ina eventuala infecziun a l'exteriur.
     travel_screen_explanation_title_2: Tge capita, sche jau endatesch il code covid?
     travel_screen_explanation_text_2: Sche Vus endatais il code covid vegnan las clavs privatas che Vus avais tramess er cundivididas cun ils pajais cumpatibels.\n\nPer che er las viagiaturas ed ils viagiaturs da l'exteriur possian vegnir infurmads, succeda quai independentamain dal fatg, sche Vus essas sezza stada resp. sez stà a l'exteriur u betg.
     accessibility_faq_button_hint_non_bag: Quest buttun banduna l'app ad avra ina pagina d'internet. 
@@ -327,8 +327,8 @@ rm:
     share_app_supertitle: Impedir…
     share_app_title: cuminaivlamain infecziuns
     share_app_button: Cundivider l'app
-    share_app_body: Sche uschè bleras persunas sco pussaivel activeschan l'app SwissCovid, pudain nus interrumper ad uras las chadainas d'infecziun.
-    share_app_message: Sche uschè bleras persunas sco pussaivel activeschan l'app SwissCovid, pudain nus interrumper ad uras las chadainas d'infecziun.
+    share_app_body: Sche uschè blers da Voss contacts sco pussaivel dovran l'app SwissCovid, pudais Vus vegnir infurmada u infurmà svelt en cas d'ina ristga d'infecziun.
+    share_app_message: Cun l'app SwissCovid pon tuts gidar da franar la derasaziun dal coronavirus.
     share_app_url: https://bag-coronavirus.ch/swisscovid-app/#download
     stats_counter: {COUNT} miu.
     stats_source_day: Ultima actualisaziun da las datas ils {DAY}
@@ -417,7 +417,7 @@ rm:
     ios_software_update_notification_title: Igl è necessari d'actualisar la software
     ios_software_update_notification_text: Vus stuais avair installà la versiun dad iOS la pli actuala, per che SwissCovid funcziunia.
     delete_infection_dialog_finish_button: Terminar
-    tracing_ended_info: I na vegnan arcunads pli nagins inscunters.\n\nIl tracing po puspè vegnir activà suenter l'isolaziun.
+    tracing_ended_info: I na vegnan arcunads pli nagins novs inscunters ed i n'è betg pli pussaivel da far novas registraziuns.\nTuttas duas funcziuns pon vegnir reactivadas uschespert che Vus avais terminà l'isolaziun.
     testlocation_url_canton_aargau: https://www.ag.ch/de/themen_1/coronavirus_2/coronavirus.jsp
     testlocation_url_canton_appenzell_ausserrhoden: https://www.ar.ch/verwaltung/departement-gesundheit-und-soziales/amt-fuer-gesundheit/informationsseite-coronavirus/
     testlocation_url_canton_appenzell_innerrhoden: https://www.ai.ch/themen/gesundheit-alter-und-soziales/gesundheitsfoerderung-und-praevention/uebertragbare-krankheiten/coronavirus
@@ -445,7 +445,7 @@ rm:
     testlocation_url_canton_vaud: https://www.vd.ch/toutes-les-actualites/hotline-et-informations-sur-le-coronavirus/
     testlocation_url_canton_zurich: https://www.zh.ch/de/gesundheit/coronavirus.html
     testlocation_url_country_liechtenstein: https://www.llv.li/inhalt/118724/amtsstellen/coronavirus
-    hearing_impaired_info: Essas Vus senza udida u avais Vus in impediment d'udida e na pudais betg telefonar a la Infoline coronavirus?\n\nAlura tramettai in e-mail a covid-support@medgate.ch
+    hearing_impaired_info: Essas Vus senza udida u avais Vus in impediment d'udida e na pudais betg telefonar?\n\nAlura tramettai in e-mail a covid-support@medgate.ch
     stats_covidcodes_title: Codes covid
     stats_cases_title: Dumber dals cas
     stats_cases_subtitle: svilup actual
@@ -462,7 +462,7 @@ rm:
     stats_cases_rel_prev_week_description: Mussa la midada da la media da 7 dis en cumparegliaziun cun il stadi d'avant in'emna.
     stats_cases_current_label: Svilup actual
     stats_cases_current_description: La grafica mussa las infecziuns novas annunziadas dals ultims 28 dis. Quai dat ina survista dal svilup actual.
-    inform_detail_infobox1_text: Vus avais in test positiv (test da PCR u test svelt d'antigens) e n'avais suenter 4 uras anc betg retschavì in code covid?\nAlura contactai la Infoline coronavirus:
+    inform_detail_infobox1_text: Avais Vus in test positiv (test da PCR u test svelt d'antigens) e n'avais suenter 4 uras anc betg retschavì in code covid?\nAlura telefonai qua:
     inform_detail_infobox1_title: Anc nagin code covid?
     homescreen_isolation_ended_popup_title: Avais Vus terminà Vossa isolaziun?
     homescreen_isolation_ended_popup_text: Il tracing po puspè vegnir activà, uschespert che Vus avais terminà l'isolaziun.
@@ -470,16 +470,16 @@ rm:
     answer_no: Na
     travel_screen_info: En gir a l'exteriur? En quests pajais funcziuna SwissCovid.
     travel_screen_compatible_countries: Pajais cumpatibels:
-    inform_code_travel_text: Per che er las viagiaturas ed ils viagiaturs da l'exteriur possian vegnir infurmads, vegnan cundivididas las clavs privatas cun las apps da corona dals pajais cumpatibels.
+    inform_code_travel_text: Per che er las viagiaturas ed ils viagiaturs da l'exteriur possian vegnir infurmads suenter in inscunter, vegnan cundivididas las clavs privatas cun las apps da corona dals pajais cumpatibels.
     stats_covidcodes_total_header: total
     stats_covidcodes_0to2days_header: actual
     stats_cases_rel_prev_week_popup_header: Midada envers l'emna precedenta
     meldungen_positive_tested_faq2_title: Tgi vegn infurmà?
-    meldungen_positive_tested_faq2_text: I vegnan infurmads tut ils contacts durant il spazi da temp da Vossa fasa d'infecziun dals {ONSET_DATE} fin a l'endataziun dal code covid, sch'i era pussaivel da s'infectar sin basa da la distanza e da la durada.
+    meldungen_positive_tested_faq2_text: I vegnan infurmads tut ils contacts durant il spazi da temp da Vossa fasa contagiusa dals {ONSET_DATE} fin a l'endataziun dal code covid, sch'igl existiva ina ristga d'infecziun – sin basa da la distanza e da la durada u sche Vus essas stada registrada/stà registrà en il medem lieu.
     inform_send_thankyou_text_onsetdate: {ONSET_DATE} – oz
-    inform_send_thankyou_text_stop_infection_chains: Uschia gidais Vus a franar las chadainas da transmissiun.
+    inform_send_thankyou_text_stop_infection_chains: Uschia gidais Vus d'avertir auters d'ina eventuala infecziun.
     inform_send_thankyou_text_onsetdate_info: Las clavs privatas da Vossa app èn vegnidas tramessas per il suandant spazi da temp:
-    android_inform_tracing_enabled_explanation: Per che Vossas clavs privatas possian vegnir cundivididas sto il tracing esser activà cun endatar in code covid.
+    inform_tracing_enabled_explanation: Per che Vossas clavs privatas possian vegnir cundivididas sto il tracing esser activà cun endatar in code covid.
     leitfaden_infopopup_text: Sche Vus schmatgais sin "{BUTTON_TITLE}", bandunais Vus l'app e midais a la pagina d'internet dal mussavia SwissCovid. Uschia vegnan tramessas a la pagina d'internet er las datas dals ultims inscunters d'eventualas infecziuns.
     leitfaden_infopopup_title: Infurmaziun mussavia SwissCovid
     germany_update_boarding_title: Cumpatibel cun la Germania
@@ -490,4 +490,179 @@ rm:
     meldungen_detail_free_test_in_x_tagen: En {COUNT} dis
     meldungen_detail_free_test_now: Ussa
     meldungen_detail_free_test_tomorrow: En 1 di
+    checkout_reminder_title: Pro memoria sortida
+    checkout_reminder_text: Vulais Vus sortir?
+    auto_checkout_title: Sortir automaticamain
+    auto_checkout_body: Vus essas sortida/sortì automaticamain.
+    qrscanner_scan_qr_text: Scannar il code QR e sa registrar
+    qrscanner_error: Il code QR n'è betg valaivel!
+    datepicker_from: Da
+    datepicker_to: Fin
+    edit_mode_addcomment: Agiuntar ina notizia
+    edit_mode_comment_placeholder: p.ex. Cun tgi essas Vus stada/stà là?
+    done_button: Finì
+    checkin_set_reminder: Pro memoria sortida
+    reminder_option_off: Off
+    authenticate_for_diary: As autentifitgai per avair access al diari
+    reminder_option_hours: {HOURS} h
+    reminder_option_minutes: {MINUTES}'
+    qr_scanner_no_camera_permission: Per pudair scannar il code QR dovra l'app access a la camera.
+    diary_title: Mias registraziuns
+    checkin_button_title: Registraziun
+    NSCameraUsageDescription: La camera è necessaria per scannar il code QR.
+    NSFaceIDUsageDescription: Permettai Face-ID per pudair acceder a moda segira a Voss diari.
+    face_id_reason_text: As autentifitgai per avair access al diari
+    checkout_button_title: Sortida
+    module_checkins_title: Registraziun
+    checkin_title: Registraziun
+    checkins_create_qr_code: Crear in code QR
+    events_title: Crear codes QR
+    check_in_now_button_title: Sa registrar ussa
+    checkin_reminder_settings_alert_title: I n'è betg stà pussaivel d'activar il pro memoria
+    checkin_reminder_settings_alert_message: Per survegnir in pro memoria da sortir stuais Vus permetter \"messadis\" en las configuraziuns da l'app.
+    checkin_reminder_option_open_settings: Adattar
+    edit_controller_title: Modifitgar
+    empty_diary_title: Anc naginas endataziuns avant maun
+    empty_diary_text: Sche Vus scannais in code QR da SwissCovid per As registrar al lieu, vegn arcunada qua automaticamain in'endataziun.
+    camera_permission_dialog_text: SwissCovid dovra l'access a la camera da Voss apparat. La camera vegn mo duvrada per scannar ils codes QR.\n
+    camera_permission_dialog_action: Permetter l'access a la camera
+    web_generator_title_placeholder: p.ex. stanza u num da l'occurrenza
+    show_pdf_button: Stampar il PDF
+    bottom_nav_tab_info: Info
+    error_network_title: Sbagl da la rait
+    error_network_text: Controllai Vossa colliaziun d'internet.
+    error_action_retry: Empruvar danovamain
+    error_notification_deactivated_title: Deactivà messadis
+    error_notification_deactivated_text: Midai las configuraziuns per vegnir infurmada/infurmà directamain en cas d'in avis.
+    error_action_change_settings: Midar las configuraziuns
+    error_camera_permission_title: Nagin access a la camera
+    error_camera_permission_text: L'app dovra access a la camera per pudair scannar il code QR.
+    error_title: Sbagl
+    qr_scanner_error_code_not_yet_valid: Il code QR n'è anc betg valaivel
+    qr_scanner_error_code_not_valid_anymore: Il code QR n'è betg pli valaivel
+    error_already_checked_in: Vus essas gia As registrada/registrà.
+    error_update_text: Quest code QR n'è betg cumpatibel cun la versiun da l'app installada. Per plaschair actualisar l'app per cuntinuar.
+    error_update_title: In update è necessari
+    error_action_update: Actualisar ussa
+    ongoing_notification_checkout_quick_action: Sortir 
+    reminder_notification_snooze_action: Snooze
+    android_ongoing_checkin_notification_channel_name: Avis permanent da sa registrar
+    ongoing_notification_title: Vus essas As registrada/registrà dapi las {TIME}.
+    checkout_save_button_title: Arcunar
+    scan_qr_code_button_title: Scannar il code QR
+    checkin_ended_title: Deactivà la registraziun
+    checkin_ended_text: Actualmain n'èsi betg pussaivel da sa registrar
+    checkin_detail_checked_out_text: Scannai in code QR da SwissCovid per As registrar al lieu.
+    checkin_detail_diary_text: Sche Vus scannais in code QR da SwissCovid per As registrar al lieu, vegn arcunada qua automaticamain in'endataziun.
+    checkin_checked_in: Vus essas As registrada/registrà
+    checkout_from_to_date: {DATE1} fin {DATE2}
+    inform_detail_covidcode_info_button: Dapli davart il code covid
+    remove_from_diary_button: Stizzar l'endataziun
+    delete_button_title: Stizzar
+    share_button_title: Cundivider
+    print_button_title: Stampar
+    module_checkins_description: Scannai in code QR da SwissCovid per As registrar al lieu.
+    inform_share_checkins_title: Cundivider las endataziuns da registraziun
+    inform_share_checkins_subtitle: Sche Vus cundividais Vossas endataziuns da registraziun, po l'app infurmar persunas ch'èn stadas registradas il medem mument en il medem lieu.
+    inform_share_checkins_select_all: Selecziunar tuttas
+    inform_dont_send_button_title: Betg trametter
+    inform_dont_share_button_title: Betg cundivider
+    inform_really_not_share_title: Propi betg cundivider?
+    inform_really_not_share_subtitle: Cun cundivider Vossas clavs privatas gidais Vus SwissCovid ad infurmar autras persunas potenzialmain infectadas ed ad impedir in'ulteriura derasaziun dal virus. Sche Vus na cundividais betg Vossas clavs privatas, na vegnan avertidas naginas persunas potenzialmain infectadas.
+    remove_diary_warning_title: Stizzar l'endataziun
+    remove_diary_warning_text: Vossa endataziun vegn stizzada definitivamain da la glista.
+    remove_diary_remove_now_button: Stizzar dal tuttafatg
+    remove_diary_warning_hide_title: Mo zuppentar e vegnir infurmada/infurmà vinavant?
+    home_covidcode_card_title: Survegnì in resultat positiv?
+    home_end_isolation_card_text: Puspè activar inscunters e registraziuns.
+    reminder_option_hours_minutes: {HOURS} h {MINUTES}'
+    checkin_overview_isolation_text: Vus na pudais betg pli As registrar, sche Vus avais survegnì in resultat positiv.
+    events_card_subtitle: Creai in code QR, cun il qual persunas pon sa registrar al lieu.
+    delete_qr_code_dialog: Vulais Vus propi stizzar il code QR? Ils codes QR stampads restan vinavant valaivels.
+    self_checkin_button_title: Autoregistraziun
+    checkin_overview_checkins_explanation: Scannai in code QR da SwissCovid per As registrar al lieu.
+    checkout_overlapping_alert_title: Betg pussaivel d'arcunar
+    checkout_overlapping_alert_description: Ils temps che Vus avais selecziunà coincidan cun autras registraziuns da Voss diari. Per plaschair controllar anc ina giada Vossas indicaziuns.
+    inform_send_thankyou_text_checkins: Las endataziuns da las registraziuns che Vus avais selecziunà èn vegnidas tramessas. Tut las persunas ch'èn stadas registradas il medem mument en il medem lieu vegnan infurmadas.
+    pdf_headline: Registraziun SwissCovid
+    pdf_slogan: Sa registrar senza inditgar datas
+    pdf_explanation: Cun l'app SwissCovid pudais Vus As registrar tar nus a moda simpla e senza inditgar Vossas datas. En cas d'ina situaziun da ristga As infurmescha l'app sveltamain.
+    pdf_swisscovid_app: App SwissCovid
+    pdf_download_app: Telechargiar ussa
+    checkin_detail_checked_out_title: Sa registrar senza inditgar datas
+    home_covidcode_card_text: Endatai qua Voss code covid per avertir autras persunas.
+    home_end_isolation_card_title: Terminar l'isolaziun?
+    events_card_title: Vulais Vus crear codes QR?
+    checkin_footer_title1: Pertge dovri ina funcziun da sa registrar?
+    checkin_footer_subtitle1: La funcziun da sa registrar senza endatar las datas da contact cumplettescha l'app SwissCovid. Cun agid da questa funcziun na pudais Vus avertir betg mo stretgs contacts en cas d'in resultat positiv, mabain er las persunas ch'èn stadas registradas il medem mument en il medem lieu.
+    checkin_footer_title2: Las datas na vegnan betg arcunadas en moda centrala.
+    checkin_footer_subtitle2: Per las registraziuns da SwissCovid na stuais Vus inditgar naginas datas persunalas sco il num, l'adressa u il numer da telefon ed i na vegnan arcunadas naginas datas da GPS davart la posiziun. La glista da las registraziuns vegn arcunada localmain sin Voss smartphone. Suenter 14 dis vegnan las datas localas puspè stizzadas.
+    events_empty_state_title: Creai in code QR
+    events_empty_state_subtitle: Cun in code QR da SwissCovid pon persunas sa registrar al lieu senza inditgar lur datas.
+    events_info_box_title: Na remplazza betg la registraziun obligatorica da datas da contact
+    events_info_box_text: Las registraziuns da SwissCovid na remplazzan betg l'obligaziun da registrar las datas da contact prescritta en l'Ordinaziun davart COVID-19 situaziun speziala.
+    events_footer_title1: En tge situaziuns pon ins duvrar la funcziun da sa registrar?
+    events_footer_title2: Pertge dovri ina funcziun da sa registrar?
+    events_footer_subtitle1: Registraziuns da SwissCovid pon vegnir en funcziun là, nua che persunas s'inscuntran, ma i na dat nagina obligaziun da registrar las datas da contact.\n\nQuai pon esser p.ex.:\n- occurrenzas privatas\n- occurrenzas d'uniuns\n- reuniuns en l'ambient professiunal sco p.ex. stanzas da seduta, biros, cantinas, etc.
+    events_footer_subtitle2: La funcziun da sa registrar senza endatar las datas da contact cumplettescha l'app SwissCovid. Cun agid da questa funcziun na pudais Vus avertir betg mo stretgs contacts en cas d'in resultat positiv, mabain er las persunas ch'èn stadas registradas il medem mument en il medem lieu.
+    meldung_detail_exposed_list_card_subtitle: Situaziun da ristga
+    meldung_detail_exposed_list_card_title_encounters: Inscunters
+    meldung_detail_exposed_list_card_title_checkin: Registraziun
+    meldung_detail_exposed_list_card_whattodo_button: Tge duai jau far?
+    debug_state_setting_option_checkin_exposed: Registraziun positiva
+    debug_state_setting_option_mutiple_exposed: Registraziuns positivas/contacts positivs
+    venue_type_user_qr_code: Code QR utilisadra/utilisader
+    venue_type_contact_tracing_qr_code: Code QR contact tracing
+    checkin_ended_text_detailed: Suenter in test positiv vegn la funcziun da sa registrar deactivada automaticamain. Ella po puspè vegnir activada, uschespert che Vus avais terminà l'isolaziun.
+    checkins_create_qr_code_subtitle: Tscherni in titel che descriva pli detagliadamain il lieu u Vossa occurrenza. Il titel vegn mussà tar la registraziun.
+    checkin_report_heading: Tge pudais Vus far?
+    checkin_report_title1: Proteger contacts
+    checkin_report_title2: Far stim da sintoms
+    checkin_report_title3: Laschar far in test
+    checkin_report_subtitle1: Vus pudais gia esser infectusa u infectus senza badar quai. Observai las mesiras d'igiena e da protecziun vertentas e protegi Vossa famiglia, Vossas amias e Voss amis sco er Voss conturn.
+    checkin_report_subtitle2: Survegliai Voss stadi da sanadad.
+    checkin_report_subtitle3: Faschai immediatamain in test, sche Vus avais sintoms. In test dal coronavirus è raschunaivel e vegn cusseglià, er sche Vus n'avais nagins sintoms e sche Vus n'essas anc betg vaccinada u vaccinà cumplettamain.
+    meldung_detail_checkin_title: Registraziun
+    not_thank_you_screen_title: I n’èn vegnidas tramessas naginas datas
+    not_thank_you_screen_text1: I n’èn vegnidas tramessas naginas clavs privatas
+    not_thank_you_screen_back_button: Enavos
+    not_thank_you_screen_dont_send_button: Trametter naginas datas
+    not_thank_you_screen_text2: I n’èn vegnidas tramessas naginas endataziuns da registraziuns
+    inform_share_checkins_send_button_title: Cundivider la selecziun
+    inform_share_checkins_not_send_button: Cundivider nagut
+    onboarding_checkin_title: Sa registrar senza inditgar datas
+    onboarding_checkin_heading: Registraziuns
+    onboarding_checkin_text1: Cun las registraziuns da SwissCovid pudais Vus As registrar cun l'app en in lieu u a chaschun d'in inscunter.
+    onboarding_checkin_text2: Vossa preschientscha vegn arcunada mo en l'app. Vus na stuais inditgar naginas datas persunalas en l'app.
+    checkin_updateboarding_text: Cun las registraziuns da SwissCovid pudais Vus As registrar cun l'app en in lieu u a chaschun d'in inscunter. Vossa preschientscha vegn arcunada mo en l'app. Vus na stuais inditgar naginas datas persunalas en l'app. Las cundiziuns d'utilisaziun e la decleraziun davart la protecziun da datas èn vegnidas actualisadas en quest connex.
+    onboarding_gaen_button_dont_activate: Sursiglir
+    remove_diary_warning_hide_text: L'endataziun vegn arcunada durant 14 dis a moda codada davosvart en l'app. Uschia èsi tuttina pussaivel d'As infurmar en cas d'ina eventuala infecziun.
+    remove_diary_warning_hide_button: Mo zuppentar
+    checkin_set_reminder_explanation: L'app As po regurdar il dretg mument da puspè sortir.
+    remove_diary_remove_now_title: U stizzar dal tuttafatg?
+    remove_diary_remove_now_text: L'endataziun vegn stizzada dal tuttafatg. I n'è betg pli pussaivel d'As avertir.
+    not_thank_you_screen_text3: Nagin na vegn infurmà.
+    checkin_report_link: Tge stoss jau savair davart il tests?
+    instant_app_install_action: Installar l'app e sa registrar
+    partial_onboarding_box_text: Terminai las configuraziuns da l'app per pudair far diever da la funcziun da tracing.
+    partial_onboarding_box_action: Terminar ussa
+    partial_onboarding_done_title: La configuraziun è terminada
+    partial_onboarding_done_text: Grazia fitg che Vus gidais a franar la derasaziun dal coronavirus.
+    web_slogan: Infurmescha svelt en cas d'ina ristga d'infecziun
     test_info_url: https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/testen.html
+    checkout_too_long_alert_text: Per questa registraziun vala ina durada da registraziun maximala da {DURATION}. Verifitgai per plaschair anc ina giada Vossa indicaziun.
+    accessibility_camera_light_on: Activar la glisch da giaglioffa
+    accessibility_camera_light_off: Deactivar la glisch da giaglioffa
+    error_cannot_enter_covidcode_while_checked_in: Vus essas anc registrada u registrà. Sorti per plaschair avant che Vus endatais il code COVID.
+    events_card_title_events_not_empty: Mes codes QR
+    checkout_inverse_time_alert_description: Voss temp da sortida tschernì è avant il temp da registraziun. Verifitgai per plaschair anc ina giada Vossa indicaziun.
+    update_notification_checkin_feature_title: Nova funcziun: Registraziun
+    update_notification_checkin_feature_text: Grazia fitg che Vus duvrais SwissCovid. Cun la versiun da l'app la pli nova pudais Vus As registrar al lieu, senza inditgar datas.
+    diary_current_title: Actual
+    ios_snooze_option_30min: Regurdar danovamain (30 min)
+    ios_snooze_option_1h: Regurdar danovamain (1 ura)
+    ios_snooze_option_2h: Regurdar danovamain (2 uras)
+    ios_notification_checkout_now: Sortir ussa
+    covid_certificate_alert_text: Duvrai per plaschair l'app «COVID Certificate» per scannar quest code QR.
+    covid_certificate_open_app: Avrir l'app
+    covid_certificate_install_app: Installar l'app

--- a/dpppt-config-backend/src/main/resources/i18n/messages_sq.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_sq.properties
@@ -311,7 +311,7 @@ sq:
     travel_title: Udhëtimi
     travel_home_description: Kontaktet e SwissCovid funksionojnë në shtetet më poshtë:
     travel_screen_explanation_title_1: Cfarë do të thotë kjo?
-    travel_screen_explanation_text_1: Nëse do të udhëtoni në një nga shtetet e përfshira, nuk keni nevojë të instaloni asnjë aplikacion tjetër për koronavirusin.\n\nSwissCovid kontrollon kodet e identifikimit në mënyrë rastësore që janë krijuar në shtetet e përfshira. Në këtë mënyrë, ju mund të paralajmëroheni edhe për një infeksion të mundshëm jashtë vendit.
+    travel_screen_explanation_text_1: Nëse jeni duke udhëtuar në një nga vendet e pajtueshme, nuk duhet të instaloni asnjë aplikacion tjetër korona (Corona-App) për kontaktet. \n\nSwissCovid kontrollon çelësat personal të publikuara në vendet e pajtueshme. Kështu edhe ju mund të paralajmëroheni për një infektim të mundshëm jashtë shtetit.
     travel_screen_explanation_title_2: Çfarë ndodh kur regjistron kodin Covid?
     travel_screen_explanation_text_2: Kur regjistroni kodin Covid, kodet e identifikimit që dërgoni do të shpërndahen gjithashtu me shtetet e përfshira.\n\nNë mënyrë që udhëtarët nga jashtë shtetit të mund të paralajmërohen, kjo bëhet pavarësisht nëse keni qenë vetë jashtë shtetit ose jo.
     accessibility_faq_button_hint_non_bag: Ky buton ju largon nga aplikacioni dhe hap një faqe interneti.
@@ -327,8 +327,8 @@ sq:
     share_app_supertitle: Së bashku…
     share_app_title: të parandalojmë infektimet
     share_app_button: Shpërndaj aplikacionin
-    share_app_body: Kur aplikacionin "SwissCovid" e aktivizojnë sa më shumë persona të jetë e mundur, atëherë ne mund ta ndërpresim më herët zinxhirin e infektimit.
-    share_app_message: Kur aplikacionin "SwissCovid" e aktivizojnë sa më shumë persona të jetë e mundur, atëherë ne mund ta ndërpresim më herët zinxhirin e infektimit.
+    share_app_body: Nëse shumë nga kontaktet tuaja përdorin mundësisht aplikacionin SwissCovid, atëherë mund të informoheni shpejt për një rrezik të infektimit.
+    share_app_message: Me aplikacionin Swiss Covid të gjithë ne mund të ndihmojmë për të frenuar përhapjen e koronavirusin.
     share_app_url: https://bag-coronavirus.ch/swisscovid-app/#download
     stats_counter: {COUNT} Mio.
     stats_source_day: Versioni i të dhënave {DAY}
@@ -468,7 +468,7 @@ sq:
     homescreen_isolation_ended_popup_text: Gjurmimi mund të riaktivizohet sapo të keni mbaruar periudhën e izolimit.
     answer_yes: Po
     answer_no: Jo
-    travel_screen_info: Udhëtim jashtë shtetit? SwissCovid punon në këto shtete.
+    travel_screen_info: Udhëtim jashtë shtetit? Në këto vende funksionojnëkontaktet e SwissCovid.
     travel_screen_compatible_countries: Shtetet e përfshira:
     inform_code_travel_text: Në mënyrë që udhëtarët nga jashtë shtetit të mund të paralajmërohen pas një kontakti, çelësat personal shpërndahen me aplikacionet për koronavirusin të vendeve të përfshira.
     stats_covidcodes_total_header: Total
@@ -479,7 +479,7 @@ sq:
     inform_send_thankyou_text_onsetdate: {ONSET_DATE} – sot
     inform_send_thankyou_text_stop_infection_chains: Duke vepruar kështu, ju ndihmoni të informoni të tjerët për një infektim të mundshëm.
     inform_send_thankyou_text_onsetdate_info: Çelësat privatë të aplikacionit tuaj janë dërguar për periudhën kohore vijuese:
-    android_inform_tracing_enabled_explanation: Kur futni një kod Covid, gjurmimi duhet të aktivizohet në mënyrë që çelësat tuaj privatë të mund të shpërndahen.
+    inform_tracing_enabled_explanation: Kur futni një kod Covid, gjurmimi duhet të aktivizohet në mënyrë që çelësat tuaj privatë të mund të shpërndahen.
     leitfaden_infopopup_text: Nëse shtypni "{BUTTON_TITLE}", dilni nga aplikacioni dhe kaloni në faqen e internetit të udhëzuesit SwissCovid. Të dhënat e takimeve të fundit të infektimeve të mundshme dërgohen gjithashtu në faqen e internetit.
     leitfaden_infopopup_title: Informacion për udhëzuesin SwissCovid
     germany_update_boarding_title: E pajtueshme me Gjermaninë
@@ -502,7 +502,7 @@ sq:
     edit_mode_comment_placeholder: psh. Me kë ishit aty?
     done_button: Gati
     checkin_set_reminder: Kujtesa e Check-out
-    reminder_option_off: Fikur
+    reminder_option_off: Off
     authenticate_for_diary: Autentifikohuni për aksesin në ditar
     reminder_option_hours: {HOURS} h
     reminder_option_minutes: {MINUTES}'
@@ -516,7 +516,7 @@ sq:
     module_checkins_title: Check-in
     checkin_title: Check-In
     checkins_create_qr_code: Krijoni kodin QR
-    events_title: Ofroni Check-ins?
+    events_title: Krijoni kodin QR
     check_in_now_button_title: Kontrollohuni tani
     checkin_reminder_settings_alert_title: Kujtesa nuk u vendos dot
     checkin_reminder_settings_alert_message: Në mënyrë që të merrni kujtesa nga Check-out, duhet të lejoni \"Njoftimet\'’ te cilësimet e aplikacionit.
@@ -564,7 +564,7 @@ sq:
     module_checkins_description: Skanoni një kod QR të SwissCovid për t’u kontrolluar në vend.
     inform_share_checkins_title: Shpërndani shënimet e Check-in
     inform_share_checkins_subtitle: Nëse shpërndani shënimet tuaja të Check-in, atëherë aplikacioni njofton personat, të cilët janë kontrolluar në të njëjtën kohë në të njëjtin vend.
-    inform_share_checkins_select_all: Zgjidhni të gjitha
+    inform_share_checkins_select_all: Zgjidhni gjithçka që përshtatet
     inform_dont_send_button_title: Mos dërgoni
     inform_dont_share_button_title: Mos shpërndani
     inform_really_not_share_title: Vërtet të mos shpërndani?
@@ -577,8 +577,8 @@ sq:
     home_end_isolation_card_text: Aktivizoni përsëri kontaktet dhe Check-in.
     reminder_option_hours_minutes: {HOURS} h {MINUTES}'
     checkin_overview_isolation_text: Ju nuk mund të kontrolloheni më, sepse keni dalë pozitiv në test.
-    events_card_subtitle: Krijoni një kod QR, me të cilin të kontrolloni personat në vend.
-    delete_qr_code_dialog: Dëshironi vërtet ta fshini kodin QR?
+    events_card_subtitle: Krijoni një kod QR për SwissCovid, me të cilin mund të kontrolloni personat në vend.
+    delete_qr_code_dialog: Dëshironi vërtet ta fshini kodin QR? Kodet e printuara QR mbeten gjithsesi të vlefshme.
     self_checkin_button_title: Self Check-In
     checkin_overview_checkins_explanation: Skanoni një kod QR të SwissCovid për t’u kontrolluar në vend.
     checkout_overlapping_alert_title: Sigurimi nuk është i mundur
@@ -592,7 +592,7 @@ sq:
     checkin_detail_checked_out_title: Kontrolli pa lënë të dhëna \n
     home_covidcode_card_text: Futni këtu kodin tuaj Covid për të informuar të tjerët.
     home_end_isolation_card_title: Keni përfunduar izolimin?
-    events_card_title: Dëshironi të ofroni Check-ins?
+    events_card_title: Dëshironi të krijoni një kod QR?
     checkin_footer_title1: Përse duhet një funksion i Check-in?
     checkin_footer_subtitle1: Aplikacioni SwissCovid zgjeron funksionin e Check-in pa futjen e të dhënave të kontaktit. Me këtë funksion, në rastin kur keni dalë pozitiv në test, ju jo vetëm që mund të informoni kontaktet e afërta, por edhe personat që janë kontrolluar në të njëjtën kohë në të njëjtin vend.
     checkin_footer_title2: Asnjë ruajtje qendrore e të dhënave
@@ -621,7 +621,7 @@ sq:
     checkin_report_title3: Kryeni testin
     checkin_report_subtitle1: Ju tashmë mund të jeni i infektuar pa e vënë re. Mbani parasysh masat e higjienës dhe të mbrojtjes dhe mbroni familjen tuaj, miqtë tuaj dhe mjedisin tuaj rrethues.
     checkin_report_subtitle2: Mbikëqyrni gjendjen tuaj shëndetësore.
-    checkin_report_subtitle3: Testohuni menjëherë gjatë shfaqjes së simptomave. Edhe nëse nuk shfaqet asnjë simptomë, testi i koronës është i arsyeshëm dhe i rekomandueshëm.
+    checkin_report_subtitle3: Testohuni menjëherë gjatë shfaqjes së simptomave. Edhe nëse nuk shfaqet asnjë simptomë dhe nuk jeni akoma i vaksinuar plotësisht, testi i koronës është i arsyeshëm dhe i rekomandueshëm.
     meldung_detail_checkin_title: Check-In
     not_thank_you_screen_title: Nuk u dërgua asnjë e dhënë
     not_thank_you_screen_text1: Nuk u dërgua asnjë çelës personal.
@@ -650,3 +650,19 @@ sq:
     partial_onboarding_done_text: Shumë faleminderit që na ndihmoni për të ndaluar zgjerimin e koronavirusit.
     web_slogan: Në rastin e një rreziku të infektimit informoheni shpejt.
     test_info_url: https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/testen.html
+    checkout_too_long_alert_text: Për këtë Check-In vlen kohëzgjatja maksimale e Check-in e {DURATION}. Kontrolloni edhe njëherë të dhënat tuaja.
+    accessibility_camera_light_on: Ndizni dritën
+    accessibility_camera_light_off: Fikni dritën
+    error_cannot_enter_covidcode_while_checked_in: Ju jeni akoma i regjistruar. Kontrolloni përpara se të futni kodin Covid.
+    events_card_title_events_not_empty: Kodi im QR
+    checkout_inverse_time_alert_description: Koha juaj e zgjedhur Checkout është përpara kohës së Check-In. Kontrolloni edhe njëherë të dhënat tuaja.
+    update_notification_checkin_feature_title: Funksion i ri: Check-In
+    update_notification_checkin_feature_text: Faleminderit për përdorimin e SwissCovid. Me versionin më të ri të aplikacionit mund të regjistroheni në vend pa lënë asnjë të dhënë.
+    diary_current_title: Aktuale
+    ios_snooze_option_30min: Kujtohuni përsëri (30 min)
+    ios_snooze_option_1h: Kujtohuni përsëri (1 orë)
+    ios_snooze_option_2h: Kujtohuni përsëri (2 orë)
+    ios_notification_checkout_now: Kontrollohuni tani
+    covid_certificate_alert_text: Për skanimin e këtij kodi QR përdorni aplikacionin ''COVID Certificate (Certifikata e COVID)''.
+    covid_certificate_open_app: Hapni aplikacionin
+    covid_certificate_install_app: Instaloni aplikacionin

--- a/dpppt-config-backend/src/main/resources/i18n/messages_sr.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_sr.properties
@@ -327,8 +327,8 @@ sr:
     share_app_supertitle: Zajedno…
     share_app_title: Sprečimo širenje infekcije
     share_app_button: Deli aplikaciju
-    share_app_body: Ako što više nas aktivira aplikaciju SwissCovid, moći ćemo pravovremeno da prekinemo lanac širenja infekcije.
-    share_app_message: Ako što više nas aktivira aplikaciju SwissCovid, moći ćemo pravovremeno da prekinemo lanac širenja infekcije.
+    share_app_body: Ako većina vaših kontakata koristi aplikaciju SwissCovid, možete brzo biti obavešteni u slučaju rizika od zaraze.
+    share_app_message: Pomoću aplikacije Swiss Covid svi možemo da pomognemo u suzbijanju širenja virusa korona.
     share_app_url: https://bag-coronavirus.ch/swisscovid-app/#download
     stats_counter: {COUNT} miliona
     stats_source_day: Stanje na dan {DAY}
@@ -478,7 +478,7 @@ sr:
     inform_send_thankyou_text_onsetdate: {ONSET_DATE} – danas
     inform_send_thankyou_text_stop_infection_chains: Na taj način pomažete da se upozore drugi o mogućosti zaraze.
     inform_send_thankyou_text_onsetdate_info: Privatni ključevi vaše aplikacije poslati su za sledeći period:
-    android_inform_tracing_enabled_explanation: Prilikom unosa kovid šifre mora se aktivirati praćenje (tracing) kako bi vaši privatni ključevi mogli da se dele.
+    inform_tracing_enabled_explanation: Prilikom unosa kovid šifre mora se aktivirati praćenje (tracing) kako bi vaši privatni ključevi mogli da se dele.
     leitfaden_infopopup_text: Kada pritisnete "{BUTTON_TITLE}" napuštate aplikaciju i dolazite na internet stranicu SwissCovid vodiča. Pri tome se podaci poslednjeg susreta sa mogućim zaražavanjem šalju internet stranici.
     leitfaden_infopopup_title: Informacije iz SwissCovid vodiča
     germany_update_boarding_title: Kompatibilno sa Nemačkom
@@ -501,10 +501,10 @@ sr:
     edit_mode_comment_placeholder: npr. S kim ste bili tamo?
     done_button: Gotovo
     checkin_set_reminder: Podsećanje na prijavu
-    reminder_option_off: Isključeno
+    reminder_option_off: Off
     authenticate_for_diary: Identifikujte se, kako biste pristupili dnevniku
-    reminder_option_hours: časovi {HOURS} h
-    reminder_option_minutes: minute {MINUTES}'
+    reminder_option_hours: {HOURS} h
+    reminder_option_minutes: {MINUTES}'
     qr_scanner_no_camera_permission: Aplikaciji je potreban pristup kameri, da bi se skenirao QR kod.
     diary_title: Moje prijave
     checkin_button_title: Prijava
@@ -515,7 +515,7 @@ sr:
     module_checkins_title: Prijava
     checkin_title: Prijava
     checkins_create_qr_code: Napraviti QR kod
-    events_title: Ponuditi prijave?
+    events_title: Napravite QR kodove
     check_in_now_button_title: Sada se prijaviti
     checkin_reminder_settings_alert_title: Podsećanje nije uspelo da se unese
     checkin_reminder_settings_alert_message: Da biste dobijali podsetnike za odjavu, morate da dozvolite \ "Obaveštenja \" u podešavanjima aplikacije.
@@ -552,7 +552,7 @@ sr:
     checkin_ended_title: Deaktivirano prijavljivanje
     checkin_ended_text: Trenutno nije moguća prijava
     checkin_detail_checked_out_text: Skenirajte SwissCovid-QR kod, kako biste se prijavili na nekoj lokaciji.
-    checkin_detail_diary_text: Ako skenirate Swiss-Covid-QR kod, da biste se prijavili na nekoj lokaciji, ovde se automatski uređuje unos.
+    checkin_detail_diary_text: Ako skenirate SwissCovid-QR kod, da biste se prijavili na nekoj lokaciji, ovde se automatski uređuje unos.
     checkin_checked_in: Prijavljeni ste
     checkout_from_to_date: {DATE1} do {DATE2}
     inform_detail_covidcode_info_button: Više o Covid kodu
@@ -563,7 +563,7 @@ sr:
     module_checkins_description: Skenirajte SwissCovid-QR kod, kako biste se prijavili na nekoj lokaciji.
     inform_share_checkins_title: Deliti unose o prijavama
     inform_share_checkins_subtitle: Kada delite unose prijave, aplikacija može istovremeno da obavesti lica, koja su se prijavila na istoj lokaciji.
-    inform_share_checkins_select_all: Izabrati sve
+    inform_share_checkins_select_all: Izaberite sve što odgovara
     inform_dont_send_button_title: Ne slati
     inform_dont_share_button_title: Ne deliti
     inform_really_not_share_title: Zaista ne deliti?
@@ -574,10 +574,10 @@ sr:
     remove_diary_warning_hide_title: Samo sakriti i nastaviti da budete obaveštavani?
     home_covidcode_card_title: Test pozitivan?
     home_end_isolation_card_text: Kontakte i prijave ponovo aktivirati. 
-    reminder_option_hours_minutes: časovi {HOURS} h minute {MINUTES}'
+    reminder_option_hours_minutes: {HOURS} h {MINUTES}'
     checkin_overview_isolation_text: Ne možete ponovo da se prijavite ako imate pozitivan test.
     events_card_subtitle: Napravite QR kod, pomoću kojeg lica mogu da se prijave na lokaciji.
-    delete_qr_code_dialog: Želite li zaista da izbrišete QR kod? 
+    delete_qr_code_dialog: Želite li zaista da izbrišete QR kod? Štampani QR kodovi ostaju i dalje na snazi.
     self_checkin_button_title: Samostalno prijavljivanje
     checkin_overview_checkins_explanation: Skenirajte SwissCovid-QR kod, kako biste se prijavili na lokaciji.
     checkout_overlapping_alert_title: Nije moguće obezbeđenje
@@ -591,7 +591,7 @@ sr:
     checkin_detail_checked_out_title: Prijaviti se bez ostavljanja podataka
     home_covidcode_card_text: Ovde unesite svoj Covid kod, kako biste upozorili druge.
     home_end_isolation_card_title: Kraj izolacije?
-    events_card_title: Želite da ponudite prijave?
+    events_card_title: Da li želite da napravite QR kodove?
     checkin_footer_title1: Čemu služi funkcija prijave?
     checkin_footer_subtitle1: Funkcija prijave bez unošenja podataka o kontaktima povećava funkcije aplikacije SwissCovid. Pomoću ove funkcije, u slučaju pozitivnog testa, možete ne samo da upozorite bliske kontakte, već i lica koja su se istovremeno prijavila na istom mestu.
     checkin_footer_title2: Nema centralnog čuvanja podataka
@@ -620,7 +620,7 @@ sr:
     checkin_report_title3: Vršiti testiranje
     checkin_report_subtitle1: Mogli biste biti zarazni, a da to ne primetite. Pridržavajte se važećih higijenskih i zaštitnih mera i zaštitite svoju porodicu, prijatelje i okolinu.
     checkin_report_subtitle2: Proveravajte svoje zdravsveno stanje.
-    checkin_report_subtitle3: Odmah se testirajte ako imate simptome. Čak i ako nema simptoma, test korone je važan i  preporučuje se.
+    checkin_report_subtitle3: Odmah se testirajte ako imate simptome. Čak i ako nema simptoma i niste u potpunosti vakcinisani, test korone je važan i  preporučuje se.
     meldung_detail_checkin_title: Prijava
     not_thank_you_screen_title: Podaci nisu poslati
     not_thank_you_screen_text1: Nisu poslati privatni ključevi.
@@ -649,3 +649,19 @@ sr:
     partial_onboarding_done_text: Hvala vam što pomažete u suzbijanju širenja virusa korone.
     web_slogan: Brze informacije u slučaju rizika od zaraze. 
     test_info_url: https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/testen.html
+    checkout_too_long_alert_text: Ova prijava važi maksimalno u trajanju od {DURATION}. Molimo vas da ponovo proverite svoje podatke.
+    accessibility_camera_light_on: Uključiti svetlo
+    accessibility_camera_light_off: Isključiti svetlo
+    error_cannot_enter_covidcode_while_checked_in: Još uvek ste prijavljeni. Molimo odjavite se pre unosa Covid koda.
+    events_card_title_events_not_empty: Moji QR kodovi
+    checkout_inverse_time_alert_description: Odabrano vreme za odjavu nalazi se je pre vremena za prijavu. Molimo vas da ponovo proverite svoje podatke.
+    update_notification_checkin_feature_title: Nova funkcija: prijava
+    update_notification_checkin_feature_text: Hvala vam što koristite SwissCovid. Sa najnovijom verzijom aplikacije možete da se prijavite na lokaciji bez ostavljanja podataka.
+    diary_current_title: Trenutno
+    ios_snooze_option_30min: Podsetiti ponovo (30min)
+    ios_snooze_option_1h: Podsetiti ponovo (1h)
+    ios_snooze_option_2h: Podsetiti ponovo (2h)
+    ios_notification_checkout_now: Sada se odjaviti
+    covid_certificate_alert_text: Molimo koristite aplikaciju "COVID certifikat" za skeniranje ovog QR koda.
+    covid_certificate_open_app: Otvoriti aplikaciju
+    covid_certificate_install_app: Instalirati aplikaciju

--- a/dpppt-config-backend/src/main/resources/i18n/messages_ti.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_ti.properties
@@ -311,7 +311,7 @@ ti:
     travel_title: መገሻታት
     travel_home_description: ምርኽኻብ SwissCovid ኣብ ዝስዕቡ ሃገራት ይሰርሕ፥
     travel_screen_explanation_title_1: እዚ እንታይ ማለት፧
-    travel_screen_explanation_text_1: ንስኹም ኣብ ሓደ ካብቶም ተቓደውቲ ሃገራት እንተትግዕዙ ኮይንኩም፣ ካልእ ኮሮና ኤፕ ከተምጽኡ ኣየድልየኩምን።\n\nSwissCovid ነቶም ኣብቶም ተቓደውቲ ሃገራት ዝተዘርገሑ ግላውያን መፋትሕ ይቈጻጸር። ንስኹም ዋላ ኣብ ክፍጸም ዝኽእል ልበዳ ኣብ ወጻኢ ክትጥንቐቑ ትኽእሉ ኢኹም።
+    travel_screen_explanation_text_1: ንስኹም ኣብ ሓደ ካብቶም ተቓደውቲ ሃገራት እንተትግዕዙ ኮይንኩም፣ ንምርኽኻብሲ ካልእ ኮሮና ኤፕ ከተምጽኡ ኣየድልየኩምን።\n\nSwissCovid ነቶም ኣብቶም ተቓደውቲ ሃገራት ዝተዘርገሑ ግላውያን መፋትሕ ይቈጻጸር። ንስኹም ዋላ ኣብ ክፍጸም ዝኽእል ልበዳ ኣብ ወጻኢ ክትጥንቐቑ ትኽእሉ ኢኹም።
     travel_screen_explanation_title_2: ኣብ ምእታው ኮቪድኮድ እንታይ ክፍጸም ድዩ፧
     travel_screen_explanation_text_2: ኣብ ምእታው ኮቪድኮድ እቶም ካባኹም ዝተሰደዱ ግላውያን መፋትሕ እንተላይ ምስቶም ተቓደውቲ ሃገራት ክካፈሉ እዮም።\n\nገየሽቲ ካብ ወጻኢ እንተላይ መታን ክጥንቀቑ፣ ባዕልኹም ኣብ ወጻኢ ትግዕዙ ኔርኩም ወይ ኣይትግዕዙን ኔርኩም ብዘየገድስ እዩ።
     accessibility_faq_button_hint_non_bag: እዚ መጠውቒ/Button ካብቲ ኤፕ ይወጽእን ሓድሽ ወብሳይት ይኸፍትን።
@@ -327,8 +327,8 @@ ti:
     share_app_supertitle: ብሓባር…
     share_app_title: ልበዳታት ምውጋድ
     share_app_button: ነቲ ኤፕ ምኽፋል
-    share_app_body: ብዝተኻእለ መጠን ብዙሓት ንSwissCovid ኤፕ እንድሕር ወሊዖሞ፣ ናይ ልበዳ ሰንሰለታት ብኣጋኡ ከነቋርጾም ንኽእል ኢና።
-    share_app_message: ብዝተኻእለ መጠን ብዙሓት ንSwissCovid ኤፕ እንድሕር ወሊዖሞ፣ ናይ ልበዳ ሰንሰለታት ብኣጋኡ ከነቋርጾም ንኽእል ኢና።
+    share_app_body: ብዝተኻእለ መጠን ብዙሓት ካብ ፈለጥትኹም ነቲ ኤፕ ዝጥቐሙሉ ኮይኖም፣ ኣብ ናይ ልበዳ ርከሳ ብቕልጡፍ ክትሕበሩ ትኽእሉ።
+    share_app_message: ብስዊስኮድ ኣፕ ዝርግሐ ናይ ኮሮናቫይረስ ንኽዕገት እጃምኩም ተበርክቱ።
     share_app_url: https://bag-coronavirus.ch/swisscovid-app/#download
     stats_counter: {COUNT} ሚልዮን
     stats_source_day: መርገጽ ዳታ {DAY}
@@ -468,7 +468,7 @@ ti:
     homescreen_isolation_ended_popup_text: ነቲ ግለላ ወዲእኹሞ እንተኾይንኩም እቲ ምክትታል መሊሱ ክውላዕ ይከኣል።
     answer_yes: እወ
     answer_no: ኣይፋል
-    travel_screen_info: ኣብ ወጻኢ ምግዓዝ፧ ኣብዚኦም ሃገራት SwissCovid ይሰርሕ እዩ።
+    travel_screen_info: ኣብ ወጻኢ ምግዓዝ፧ ኣብዚኦም ሃገራት ምርኽኻብ SwissCovid ይሰርሕ እዩ።
     travel_screen_compatible_countries: ተቓደውቲ ሃገራት፥
     inform_code_travel_text: ገየሽቲ ካብ ወጻኢ ውን ድሕሪ ምርኽኻብ መጠንቀቕታ መታን ክወሃቡ፣ እቶም ግላውያን መፋትሕ ምስቶም ኮሮና ኤፕስ ናይቶም ተቓደውቲ ሃገራት ክካፈሉ እዮም።
     stats_covidcodes_total_header: ጥቕላላ
@@ -479,7 +479,7 @@ ti:
     inform_send_thankyou_text_onsetdate: {ONSET_DATE} – ሎሚ
     inform_send_thankyou_text_stop_infection_chains: በዚ መንገዲ‘ዚ ካልኦት ሰባት ካብ ክፍጸም ዝኽእል ልበዳ ንክጥንቀቑ ትሕግዙ ኣለኹ።
     inform_send_thankyou_text_onsetdate_info: ግላውያን መፋትሕ ናይ ኤፕኩም ንዝስዕብ እዋን ተሰዲዶም ኔሮም፥
-    android_inform_tracing_enabled_explanation: ኣብ ምእታው ኮቪድ-ኮድ እቲ ምክትታል ክውላዕ ኣለዎ፣ ግላዊ መፍትሕኩም ክካፈል መታን ክከኣል።
+    inform_tracing_enabled_explanation: ኣብ ምእታው ኮቪድ-ኮድ እቲ ምክትታል ክውላዕ ኣለዎ፣ ግላዊ መፍትሕኩም ክካፈል መታን ክከኣል።
     leitfaden_infopopup_text: መጠወቒ "{BUTTON_TITLE}" ትጥውቕዎ እንተኾይንኩም፣ ካብቲ ኤፕ ትወጽኡ ከምኡ'ውን ናብቲ መርበብ ኢንተርነት መምርሒ SwissCovid ክትቕይሩ። ሽዑ ሓበሬታ/ዳታ ናይ ተፈጺሞም ዝኾኑ ልበዳታት ናይቲ ዝሓለፈ ምርኽኻብ ካብቲ መርበብ ኢንተርነት እንተላይ ይስደዱ።
     leitfaden_infopopup_title: ሓበሬታ መምርሒ SwissCovid
     germany_update_boarding_title: ምስ ጀርመን ዝሰማማዕ 
@@ -515,7 +515,7 @@ ti:
     module_checkins_title: ቸክ-ኢን
     checkin_title: ቸክ-ኢን
     checkins_create_qr_code: QR-ኮድ ምፍጣር
-    events_title: ቸክ-ኢን ምቕራብ
+    events_title: ምፍጣር ኮድ QR
     check_in_now_button_title: ሕጂ ቸክ-ኢን ምእታው
     checkin_reminder_settings_alert_title: እቲ መዘኻኸሪ ክዕቀብ ኣይከኣለን
     checkin_reminder_settings_alert_message: ናይ ቸክ-ኣውት መዘኻኸሪታት መታን ክትቕበሉ \"Mitteilungen/መልእኽትታት\" ኣብቲ ምስትኽኽእል ኤፕ ከተፍቕዱ ኣለኩም።
@@ -563,7 +563,7 @@ ti:
     module_checkins_description: ሓደ ናይ SwissCovid QR ኮድ ስከን ግበሩ ኣብቲ ቦታ ምእንቲ ብቸክ-ኢን ክትኣትው።
     inform_share_checkins_title: ቸክ-ኢን መዝገበኣት ምክፍፋል
     inform_share_checkins_subtitle: ናይ ቸክ-ኢን መዝገባትኩም እንድሕር ኣካፊልኩም፣ እቲ ኤፕ ኣብ ማዕረ ግዜ ኣብ ሽዑ ቦታ ኔሮም ዝነበሩ ሰባት ክሕብሮም ይኽእል።
-    inform_share_checkins_select_all: ኩሉ ምምራጽ
+    inform_share_checkins_select_all: ኩሉ ብቑዕ ዝኾነ ምምራጽ
     inform_dont_send_button_title: ኣይትስደድ
     inform_dont_share_button_title: ዘይምክፍፋል
     inform_really_not_share_title: ናይ ብሓቂ ብዘይ ምክፍፋል፧
@@ -576,8 +576,8 @@ ti:
     home_end_isolation_card_text: ምርኽኻብን ቸክ-ኢንን እንደገና ምውላዕ።
     reminder_option_hours_minutes: {HOURS} h {MINUTES}'
     checkin_overview_isolation_text: ፖዚቲቭ ቸክ-ኢን እንድሕር ጌርኩም፣ ክትኣትዉ ኣይትኽእሉን ኢኹም።
-    events_card_subtitle: ኮድ QR ምስፈጠርካዮ ብእኡ ሰባት ኣብቲ ቦታ ክኣትዉ ይኽእሉ።
-    delete_qr_code_dialog: ነቲ ኮድ QR ናይብሓቂ ክትድምሥዎ ደሊኹም ዶ፧
+    events_card_subtitle: ኮድ QR SwissCovid ምስፈጠርካዮ ብእኡ ሰባት ኣብቲ ቦታ ክኣትዉ ይኽእሉ።
+    delete_qr_code_dialog: ነቲ ኮድ QR ናይብሓቂ ክትድምስሱዎ ደሊኹም ዶ፧ ዝተሓተሙ ኮዳት QR ቀጺሎም ብቑዓት እዮም።
     self_checkin_button_title: ባዕልኻ እትገብር ቸክ-ኢን
     checkin_overview_checkins_explanation: ሓደ ናይ SwissCovid QR ኮድ ስከን ግበሩ ኣብቲ ቦታ ምእንቲ ብቸክ-ኢን ክትኣትው።
     checkout_overlapping_alert_title: ምዕቃብ ዝከኣል ኣይኮነን
@@ -591,7 +591,7 @@ ti:
     checkin_detail_checked_out_title: ቸክ-ኢን ብዘይ ሓበሬታ\nምግዳፍ
     home_covidcode_card_text: ኣብዚ ኮቪድ ኮድኩም ኣእትዉ ንካልኦት መታን ከተጠንቅቕዎም።
     home_end_isolation_card_title: ግላለ ምዝዛም፧
-    events_card_title: ቸክ-ኢን ከተቕርቡ ደሊኹም ዶ፧
+    events_card_title: ኮዳት QR ብሓድሽ ክትፈጥሩ ደሊኹም፧
     checkin_footer_title1: ስለምንታይ ናይ ቸክ-ኢን ኣገባብ፧
     checkin_footer_subtitle1: ናይ ቸክ-ኢን ኣገባብ ብዘይ ምሓዝ ሓበሬታ ርክብ ነቲ SwissCovid ኤፕ ይውስኾ። ምስዚ ኣገባብ‘ዚ ፖዚቲቭ እንተ ደኣ ተመርሚርኩም፣ ጥራይ ቀረባ ርክባት ዘይኮነ ዋላ ውን ኣብ ማዕረ ግዜን ማዕረ ቦታን ኣትዮም ዝነበርይ ሰባት ከተጠንቅቕዎም ትኽእሉ።
     checkin_footer_title2: ማእከላዊ ዕቃበ ዳታ የለን
@@ -620,7 +620,7 @@ ti:
     checkin_report_title3: ምምርማር
     checkin_report_subtitle1: ድሮ ተላጋቢ ክትኮኑ ትኽእሉ ከይተገንዘብኩም። እቶም ብቑዓት ናይ ጽሬትን ምክልኻልን ስጉምትታት ተኸተሉ ከምኡውን ስድራኹምን ኣዕሩኽትኹምን ከባብኹምን ኣስተውዕሉ።
     checkin_report_subtitle2: መርገጽ ጥዕናኹም ተኸታተሉ።
-    checkin_report_subtitle3: ኣብ ምቕልቓል ምልክታት ብዝቐልጠፈ ተመርመሩ። ዋላ ምልክታት ዘይቕልቀሉ እንተኾይኖም፣ መርመራ ኮሮና ጤቓምን ዝምረጽን እዩ።
+    checkin_report_subtitle3: ኣብ ምቕልቓል ምልክታት ብዝቐልጠፈ ተመርመሩ። ዋላ ምልክታት ዘይቕልቀሉ እንተኾይኖም ኮምኡውን ገና ብምልኡ ዘይተኸተብኩም እንተኾይንኩም፣ መርመራ ኮሮና እንተላይ ጤቓምን ዝምረጽን እዩ።
     meldung_detail_checkin_title: ቸክ-ኢን
     not_thank_you_screen_title: ዝኾነ ዳታ ኣይተሰደደን
     not_thank_you_screen_text1: ዝኾነ ግላዊ መፍትሕ ኣይተሰደደን።
@@ -649,3 +649,19 @@ ti:
     partial_onboarding_done_text: ምዝርጋሕ ኮሮናቫይረስ ንምድራት እትገብሩ ምትሕብባር ነመስግነኩም ኢና።
     web_slogan: ኣብ ርከሳ ልበዳ ብቕልጡፍ ተሓቢርኩም።
     test_info_url: https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/testen.html
+    checkout_too_long_alert_text: ነዚ ቸክ-ኢን እዋኑ ልዕሊ {DURATION} ክወስድ የብሉን። እንደገና ዝሃብኩም ሓበሬታ ተቈጻጸሩ ብኽብረትኩም።
+    accessibility_camera_light_on: ልቺ ምውላዕ
+    accessibility_camera_light_off: ልቺ ምጥፋእ
+    error_cannot_enter_covidcode_while_checked_in: ገና ኣቲኹም ኣለኹም። ኮቪድኮድ ቅድሚ ትህቡ ብኽብረትኩም ውጹ።
+    events_card_title_events_not_empty: ናተይ ኮዳት QR
+    checkout_inverse_time_alert_description: ዝመረጽኩም ቸክ-ኣውት ግዜ ቅድሚ ቸክ-ኢን ግዜ እዩ ዘሎ። እቲ ዝሃብኩም ሓበሬታ እንደገና ተቈጻጸሩ ብኽብረትኩም።
+    update_notification_checkin_feature_title: ሓድሽ ኣገባብ፥ ቸክ-ኢን
+    update_notification_checkin_feature_text: ናይ ምጥቓም SwissCovid ነመስግነኩም። በቲ ሓድሽ ቨርዝዮን ኤፕ ዝኾነ ሓበሬታ ከይገደፍኩም ኣብቲ ቦታ ቸክ-ኢን/ክትኣትዉ ትኽእሉ።
+    diary_current_title: ሕጂ
+    ios_snooze_option_30min: እንደገና ኣዘክር (30 ደቓይቕ)
+    ios_snooze_option_1h: እንደገና ኣዘክር (1 ሰዓት)
+    ios_snooze_option_2h: እንደገና ኣዘክር (2 ሰዓት)
+    ios_notification_checkout_now: ሕጂ ቸክ-ኣውት/ምውጻእ
+    covid_certificate_alert_text: ነዚ QR-ኮድ ስኬን ንክትገብርዎ እቲ "COVID Certificate" ዝብሃል ኤፕ ተጠቐምሉ ብኽብረትኩም።
+    covid_certificate_open_app: ኤፕ ምኽፋት
+    covid_certificate_install_app: ኤፕ ምትካል

--- a/dpppt-config-backend/src/main/resources/i18n/messages_tr.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_tr.properties
@@ -311,7 +311,7 @@ tr:
     travel_title: Seyahatler
     travel_home_description: SwissCovid temas takibi şu ülkelerde çalışır:
     travel_screen_explanation_title_1: Bunun anlamı nedir?
-    travel_screen_explanation_text_1: Uyumlu ülkelerin birinde seyahat ettiğinizde, başka bir Korona uygulamasını kurmak zorunda kalmazsınız.\n\nSwissCovid uyumlu ülkelerde yayınlanan özel kodlar kontrol eder. Böylece yurt dışındaki olası bir bulaşı durumunda da uyarılabilirsiniz.
+    travel_screen_explanation_text_1: Uyumlu ülkelerden birinde seyahat ediyorsanız karşılaşmalar için başka bir Corona uygulaması kurmanıza gerek kalmaz.\n\nSwissCovid uyumlu ülkelerde yayınlanmış olan kişisel kodu kontrol eder. Böylece yurt dışında da olası bir bulaşma halinde uyarı alabilirsiniz.
     travel_screen_explanation_title_2: Covid kodu girildiğinde neler olur?
     travel_screen_explanation_text_2: Covid kodu girildiğinde tarafınızdan girilen özel kodlar uyumlu olan ülkelerle de paylaşılır.\n\nYurt dışı seyahatlerinden gelen kişilerin de uyarılabilmesi için bu, sizin yurt dışı seyahatinde bulunmuş olup olmamanıza bağlı kalmaksızın uygulanır.
     accessibility_faq_button_hint_non_bag: Bu buton, uygulamadan çıkarak bir web sayfası açar.
@@ -328,8 +328,8 @@ tr:
     share_app_supertitle: Birlikte…
     share_app_title: Bulaşma riskini ortadan kaldıralım. 
     share_app_button: Uygulamayı paylaş
-    share_app_body: SwissCovid uygulaması ne kadar çok kişi tarafından kullanılırsa, enfeksiyon zinciri o kadar erken kırılabilir.
-    share_app_message: SwissCovid uygulaması ne kadar çok kişi tarafından kullanılırsa, enfeksiyon zinciri o kadar erken kırılabilir.
+    share_app_body: Temasta olduğunuz kişilerin olabildiğince fazlası SwissCovid uygulamasını kullanıyorsa, olası bir bulaşma durumunda hızlıca bilgi alabilirsiniz.
+    share_app_message: SwissCovid uygulaması ile Korona virüsünün yayılımını sınırlandırmaya yardımcı olabilirsiniz.
     share_app_url: https://bag-coronavirus.ch/swisscovid-app/#download
     stats_counter: {COUNT} Milyon.
     stats_source_day: Verilerin Durumu {DAY}
@@ -469,7 +469,7 @@ tr:
     homescreen_isolation_ended_popup_text: İzolasyonu sonlandırdığınız anda izleme tekrar etkin hale getirilebilir.
     answer_yes: Evet
     answer_no: Hayır
-    travel_screen_info: Yurt dışı seyahatinde misiniz? SwissCovid bu ülkelerde çalışır.
+    travel_screen_info: Yurt dışında seyahat mi ediyorsunuz? Bu ülkelerde SwissCovid karşılaşmalar çalışır.
     travel_screen_compatible_countries: Uyumlu ülkeler:
     inform_code_travel_text: Yurt dışından gelen ziyaretçilerin de bir temastan sonra uyarılabilmesi için kişiye özel kodlar uygulamaları uyumlu olan ülkelerin korona uygulamalarıyla paylaşılır.
     stats_covidcodes_total_header: Toplam
@@ -480,7 +480,7 @@ tr:
     inform_send_thankyou_text_onsetdate: {ONSET_DATE} – bugün
     inform_send_thankyou_text_stop_infection_chains: Bu şekilde diğer kişilerin olası bir bulaşmaya karşı uyarılmasına yardım etmiş olursunuz.
     inform_send_thankyou_text_onsetdate_info: Uygulamanızın özel anahtarları şu zaman aralığı için gönderildi:
-    android_inform_tracing_enabled_explanation: Bir Covid kodu girerken, özel anahtarlarınızın paylaşılabilmesi için izleme etkinleştirilmiş olmalıdır.
+    inform_tracing_enabled_explanation: Bir Covid kodu girerken, özel anahtarlarınızın paylaşılabilmesi için izleme etkinleştirilmiş olmalıdır.
     leitfaden_infopopup_text: "{BUTTON_TITLE}" üzerine basarsanız, uygulamadan çıkıp SwissCovid rehberinin web sitesine gidersiniz. Bu esnada olası bulaşmalara ait son karşılaşmaların verileri de web sitesine gönderilir.
     leitfaden_infopopup_title: SwissCovid rehberi bilgisi
     germany_update_boarding_title: Almanya ile uyumlu
@@ -502,7 +502,7 @@ tr:
     edit_mode_comment_placeholder: Örn. kiminle oradaydınız?
     done_button: Bitti
     checkin_set_reminder: Check-out hatırlatması
-    reminder_option_off: Kapalı
+    reminder_option_off: Off
     authenticate_for_diary: Günlüğe erişim için kendinizi yetkilendirin
     reminder_option_hours: {HOURS} h
     reminder_option_minutes: {MINUTES}'
@@ -516,7 +516,7 @@ tr:
     module_checkins_title: Check-in
     checkin_title: Check-in
     checkins_create_qr_code: Kare kod oluşturun
-    events_title: Check-in’leri öner?
+    events_title: Kare kodlar oluşturun
     check_in_now_button_title: Şimdi check-in yap
     checkin_reminder_settings_alert_title: Hatırlatma oluşturulamadı
     checkin_reminder_settings_alert_message: Check-out hatırlatmasını alabilmeniz için uygulama ayarlarında \”Bildirimler\”e izin verin.
@@ -553,7 +553,7 @@ tr:
     checkin_ended_title: Check-in devre dışı
     checkin_ended_text: Şu anda check-in yapılamıyor
     checkin_detail_checked_out_text: Bulunduğunuz yere check-in yapmak için bir SwissCovid kare kodunu tarayın.
-    checkin_detail_diary_text: Bir yere check-in yapmak için bir Swiss-Covid kare kodunu taradığınızda buraya otomatik olarak bir kayıt oluşturulur.
+    checkin_detail_diary_text: Bir yere check-in yapmak için bir SwissCovid kare kodunu taradığınızda buraya otomatik olarak bir kayıt oluşturulur.
     checkin_checked_in: Check-in yaptınız
     checkout_from_to_date: {DATE1} ile {DATE2} arasında
     inform_detail_covidcode_info_button: Covid kodu hakkında daha fazla bilgi
@@ -564,7 +564,7 @@ tr:
     module_checkins_description: Bulunduğunuz yere check-in yapmak için bir SwissCovid kare kodunu tarayın.
     inform_share_checkins_title: Check-in kayıtlarını paylaş
     inform_share_checkins_subtitle: Check-in kayıtlarınızı paylaştığınızda, uygulama aynı zaman aralığında aynı yerde check-in yapmış olan kişileri bu durum hakkında bilgilendirebilir.
-    inform_share_checkins_select_all: Tümünü seç
+    inform_share_checkins_select_all: Uygun olanların hepsini seçin
     inform_dont_send_button_title: Gönderme
     inform_dont_share_button_title: Paylaşma
     inform_really_not_share_title: Gerçekten paylaşılmasın mı?
@@ -577,8 +577,8 @@ tr:
     home_end_isolation_card_text: Temasları ve Check-in’i yeniden aktif et.
     reminder_option_hours_minutes: {HOURS} h {MINUTES}'
     checkin_overview_isolation_text: Test sonucunuz pozitif ise artık check-in yapamazsınız.
-    events_card_subtitle: Kişilerin ilgili yere check-in yapabileceği bir kare kod oluşturun.
-    delete_qr_code_dialog: Kare kodu gerçekten silmek istiyor musunuz?
+    events_card_subtitle: Kişilerin yerinde check-in yapabileceği bir SwissCovid kare kod oluşturun.
+    delete_qr_code_dialog: Kare kodu gerçekten silmek istiyor musunuz? Yazdırılmış QR kodlar geçerliliğini korur.
     self_checkin_button_title: Kendi kendine check-in
     checkin_overview_checkins_explanation: Bulunduğunuz yere check-in yapmak için bir SwissCovid kare kodunu tarayın.
     checkout_overlapping_alert_title: Emniyete alınamıyor
@@ -592,7 +592,7 @@ tr:
     checkin_detail_checked_out_title: Kayıtlı veri \nbırakmadan check-in yap
     home_covidcode_card_text: Başkalarını uyarmak için covid kodunuzu buraya girin.
     home_end_isolation_card_title: İzolasyonu sonlandır?
-    events_card_title: Check-in’leri önermek mi istiyorsunuz?
+    events_card_title: Kare kodlar mı oluşturmak istiyorsunuz?
     checkin_footer_title1: Bir check-in uygulaması neden gerekli?
     checkin_footer_subtitle1: İletişim verileri olmadan çalışan check-in fonksiyonu SwissCovid uygulamasının kapsamını genişletiyor. Bu fonksiyon ile testinizin pozitif sonuçlanması halinde sadece yakın temasta bulunduğunuz kişileri değil, aynı zaman aralığında aynı yerde check-in yapmış olan kişileri de uyarabilirsiniz.
     checkin_footer_title2: Merkezi veri kaydı yok
@@ -621,7 +621,7 @@ tr:
     checkin_report_title3: Test yaptırın
     checkin_report_subtitle1: Henüz kendiniz fark etmeden de hastalığı bulaştırabilirsiniz. Geçerli hijyen ve koruma önlemlerini dikkate alın ve ailenizi, arkadaşlarınızı ve çevrenizi koruyun.
     checkin_report_subtitle2: Sağlık durumunuzu gözetim altında tutun.
-    checkin_report_subtitle3: Kendinizde semptomların varlığını gözlemlediğinizde hemen test yaptırın. Semptomlar olmadığında da bir korona testi mantıklıdır ve tavsiye edilmektedir.
+    checkin_report_subtitle3: Kendinizde semptomların varlığını gözlemlediğinizde hemen test yaptırın. Semptomlar olmadığında ve ilgili tüm aşıları olmadıysanız da bir korona testi mantıklıdır ve tavsiye edilmektedir.
     meldung_detail_checkin_title: Check-in
     not_thank_you_screen_title: Gönderilen veri yok
     not_thank_you_screen_text1: Gönderilen özel kod yok.
@@ -650,3 +650,19 @@ tr:
     partial_onboarding_done_text: Korona virüsün yayılmasını önlemeye yardımcı olduğunuz için teşekkür ederiz.
     web_slogan: Bir bulaş riski durumunda hızlıca bilgi sahibi olun.
     test_info_url: https://www.bag.admin.ch/bag/en/home/krankheiten/ausbrueche-epidemien-pandemien/aktuelle-ausbrueche-epidemien/novel-cov/testen.html
+    checkout_too_long_alert_text: Bu check-in için maksimum {DURATION}’lik bir check-in süresi geçerlidir. Lütfen girişinizi bir kez daha kontrol edin.
+    accessibility_camera_light_on: Işık açık
+    accessibility_camera_light_off: Işık kapalı
+    error_cannot_enter_covidcode_while_checked_in: Hala check-in yapmış durumdasınız. Lütfen Covid kodunu girmeden önce check-out yapın.
+    events_card_title_events_not_empty: Kare kodlarım
+    checkout_inverse_time_alert_description: Seçmiş olduğunuz check-out saati check-in saatinizden önce. Lütfen girişlerinizi bir kez daha kontrol edin.
+    update_notification_checkin_feature_title: Yeni fonksiyon: Check-in
+    update_notification_checkin_feature_text: SwissCovid’i kullandığınız için teşekkür ederiz. Bu en yeni uygulama versiyonu ile geride veri bırakmadan yerinde check-in yapabilirsiniz.
+    diary_current_title: Güncel
+    ios_snooze_option_30min: Yeniden hatırlat (30dak)
+    ios_snooze_option_1h: Yeniden hatırlar (1s)
+    ios_snooze_option_2h: Yeniden hatırlar (2s)
+    ios_notification_checkout_now: Şimdi check-out yap
+    covid_certificate_alert_text: Lütfen bu kare kodu okutmak için “COVID Certificate” uygulamasını kullanın.
+    covid_certificate_open_app: Uygulamayı aç
+    covid_certificate_install_app: Uygulamayı kur

--- a/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_bs.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_bs.properties
@@ -1,0 +1,15 @@
+bs:
+    v1_legacy_inform_detail_box_subtitle: Sa Covid šifrom...
+    v1_legacy_inform_detail_box_title: Zaustavljanje lanca širenja infekcije
+    v1_legacy_inform_detail_box_button: Unos Covid šifre
+    v1_legacy_inform_detail_box_text: Unosom Covid šifre obaveštavate aplikaciju da ste testirani pozitivno na virus korona.
+    v1_legacy_inform_detail_faq1_title: Šta je Covid šifra?
+    v1_legacy_inform_detail_faq1_text: Osobe pozitivno testirane na korona virus (PCR test ili antigen (brzi test) dobijaju kovid šifru.\n\nTime se obezbeđuje da samo potvrđeni slučajevi budu prijavljeni preko aplikacije.
+    v1_legacy_inform_detail_faq2_title: Šta se šalje?
+    v1_legacy_inform_detail_faq2_text: Šalju se samo privatni identifikacioni ključevi iz vaše aplikacije, a ne šalju se lični podaci.\n\nTime drugi korisnici aplikacije SwissCovid mogu da saznaju da postoji mogućnost infekcije.
+    v1_legacy_inform_detail_faq3_text: Iako se lični podaci koji se odnose na vas ne šalju, možda se neko seća svog kontakta sa vama na osnovu datuma.
+    v1_legacy_inform_detail_faq3_title: Da li ostajem anoniman?
+    v1_legacy_infoline_coronavirus_number: +41 58 387 77 80
+    v1_legacy_hearing_impaired_info: Da li ste bez sluha ili imate smetnju sluha i ne možete nazvati Infoline Coronavirus?\n\nOnda pošaljite e-mail na covid-support@medgate.ch
+    v1_legacy_inform_detail_infobox1_text: Pozitivno ste testirani (PCR test ili antigen brzi test) i ni posle 4 sata niste dobili kovid šifru?\nU tom slučaju kontaktirajte Infoline Coronavirus:
+    v1_legacy_inform_detail_infobox1_title: Još niste dobili Covid šifru?

--- a/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_de.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_de.properties
@@ -1,0 +1,15 @@
+de:
+    v1_legacy_inform_detail_box_subtitle: Mit dem Covidcode...
+    v1_legacy_inform_detail_box_title: Infektionsketten stoppen
+    v1_legacy_inform_detail_box_button: Covidcode eingeben
+    v1_legacy_inform_detail_box_text: Mit der Eingabe des Covidcodes teilen Sie der App mit, dass Sie positiv auf das Coronavirus getestet wurden.
+    v1_legacy_inform_detail_faq1_title: Was ist ein Covidcode?
+    v1_legacy_inform_detail_faq1_text: Positiv auf das Coronavirus getestete Personen (PCR-Test oder Antigen-Schnelltest) erhalten einen Covidcode.\n\nDamit wird sichergestellt, dass nur bestätigte Fälle über die App gemeldet werden.
+    v1_legacy_inform_detail_faq2_title: Was wird gesendet?
+    v1_legacy_inform_detail_faq2_text: Es werden nur die privaten Schlüssel Ihrer App gesendet, keine persönlichen Daten.\n\nDamit erfahren andere SwissCovid App Nutzer, dass die Möglichkeit einer Ansteckung besteht.
+    v1_legacy_inform_detail_faq3_text: Obwohl keine Daten zu Ihrer Person gesendet werden, kann es sein, dass sich jemand anhand des Datums an die Begegnung erinnern kann.
+    v1_legacy_inform_detail_faq3_title: Bleibe ich anonym?
+    v1_legacy_infoline_coronavirus_number: +41 58 387 77 80
+    v1_legacy_hearing_impaired_info: Sind Sie gehörlos oder hörbehindert und können die Infoline Coronavirus nicht anrufen?\n\nDann senden Sie eine E-Mail an covid-support@medgate.ch
+    v1_legacy_inform_detail_infobox1_text: Sie wurden positiv getestet (PCR-Test oder Antigen-Schnelltest) und haben nach 4h noch keinen Covidcode erhalten?\nDann kontaktieren Sie die Infoline Coronavirus:
+    v1_legacy_inform_detail_infobox1_title: Noch keinen Covidcode?

--- a/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_en.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_en.properties
@@ -1,0 +1,15 @@
+en:
+    v1_legacy_inform_detail_box_subtitle: With the Covidcode
+    v1_legacy_inform_detail_box_title: Break the chains of infection
+    v1_legacy_inform_detail_box_button: Enter the Covidcode
+    v1_legacy_inform_detail_box_text: By entering the Covidcode, you tell the app that you have tested positive for the coronavirus.
+    v1_legacy_inform_detail_faq1_title: What is a Covidcode?
+    v1_legacy_inform_detail_faq1_text: People who test positive for coronavirus (with a PCR test or rapid antigen test) will receive a Covidcode.\n\nThis guarantees that only confirmed cases are reported via the app.
+    v1_legacy_inform_detail_faq2_title: What information gets sent?
+    v1_legacy_inform_detail_faq2_text: Only the private keys from your app are sent, no personal data. \n\nOther SwissCovid apps can then check if it is possible that they have been infected.
+    v1_legacy_inform_detail_faq3_text: Although no personal data relating to you is sent out, it may well be that someone remembers their encounter with you from the date.
+    v1_legacy_inform_detail_faq3_title: Does anyone find out who I am?
+    v1_legacy_infoline_coronavirus_number: +41 58 387 77 80
+    v1_legacy_hearing_impaired_info: Are you deaf or hard of hearing and unable to call the coronavirus infoline on the phone?\n\nSend an email to covid-support@medgate.ch.
+    v1_legacy_inform_detail_infobox1_text: Have you tested positive (PCR test or rapid antigen test) and did not receive a Covidcode after 4 hours?\nIf so, contact the Coronavirus Infoline:
+    v1_legacy_inform_detail_infobox1_title: Don’t have a Covidcode yet?

--- a/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_es.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_es.properties
@@ -1,0 +1,15 @@
+es:
+    v1_legacy_inform_detail_box_subtitle: Con el código Covid…
+    v1_legacy_inform_detail_box_title: Parar las cadenas de contagio
+    v1_legacy_inform_detail_box_button: Introducir el código Covid
+    v1_legacy_inform_detail_box_text: Al introducir el código Covid, está usted informando a la aplicación de que ha dado positivo en el test del coronavirus.
+    v1_legacy_inform_detail_faq1_title: ¿Qué es el código Covid?
+    v1_legacy_inform_detail_faq1_text: Las personas que han dado positivo al coronavirus (test PCR o test rápido de antígenos) reciben un código Covid.\n\nAsí queda garantizado que solo se notifiquen casos confirmados a través de la aplicación.
+    v1_legacy_inform_detail_faq2_title: ¿Qué es lo que se envía?
+    v1_legacy_inform_detail_faq2_text: Solamente se envían las claves privadas de la aplicación y no los datos personales. \n\nDe esta forma, se informa a otros usuarios de la aplicación SwissCovid de que existe la posibilidad de contagio.
+    v1_legacy_inform_detail_faq3_text: A pesar de que no se envían datos sobre su persona, es posible que alguien recuerde por la fecha haber tenido contacto con usted.
+    v1_legacy_inform_detail_faq3_title: ¿Permanezco en el anonimato?
+    v1_legacy_infoline_coronavirus_number: +41 58 387 77 80
+    v1_legacy_hearing_impaired_info: ¿Es usted sordo o tiene una discapacidad auditiva y no puede llamar a la Infoline del coronavirus?\n\nEnvíe un correo electrónico a covid-support@medgate.ch
+    v1_legacy_inform_detail_infobox1_text: ¿Ha dado usted positivo (test PCR o test rápido de antígenos) y no ha recibido el código Covid después de 4 horas?\nContacte con la Infoline del coronavirus:
+    v1_legacy_inform_detail_infobox1_title: ¿Aún no ha recibido el código Covid?

--- a/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_fr.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_fr.properties
@@ -1,0 +1,15 @@
+fr:
+    v1_legacy_inform_detail_box_subtitle: Avec le code COVID…
+    v1_legacy_inform_detail_box_title: Interrompre les chaînes d'infection
+    v1_legacy_inform_detail_box_button: Entrer le code COVID
+    v1_legacy_inform_detail_box_text: En saisissant le code COVID, vous indiquez à l'application que vous avez été testé positif au nouveau coronavirus.
+    v1_legacy_inform_detail_faq1_title: Qu'est-ce qu'un code COVID ?
+    v1_legacy_inform_detail_faq1_text: Les personnes testées positives au coronavirus (test PCR ou test rapide antigénique) reçoivent un code COVID.\n\nCeci permet de garantir que seuls les cas confirmés sont déclarés dans l'application.
+    v1_legacy_inform_detail_faq2_title: Qu'est-ce qui est envoyé ?
+    v1_legacy_inform_detail_faq2_text: Seules les clés privées de votre application sont envoyées, aucune donnée personnelle.\n\nAinsi, d'autres utilisateurs de l'application SwissCovid apprennent qu'ils ont peut-être été infectés.
+    v1_legacy_inform_detail_faq3_text: Même si aucune donnée personnelle n'est envoyée sur vous, il est possible que quelqu'un se souvienne du contact sur la base de la date.
+    v1_legacy_inform_detail_faq3_title: Est-ce que je reste anonyme ?
+    v1_legacy_infoline_coronavirus_number: +41 58 387 77 80
+    v1_legacy_hearing_impaired_info: Vous êtes sourd ou malentendant et vous ne pouvez pas appeler l'infoline dédiée au coronavirus ? \n\nAlors envoyez un message à covid-support@medgate.ch.
+    v1_legacy_inform_detail_infobox1_text: Vous avez été testé positif (test PCR ou test rapide antigénique) mais vous n'avez pas encore reçu de code COVID après 4 heures ?\nContactez l'infoline coronavirus :
+    v1_legacy_inform_detail_infobox1_title: Pas encore de code COVID ?

--- a/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_hr.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_hr.properties
@@ -1,0 +1,15 @@
+hr:
+    v1_legacy_inform_detail_box_subtitle: Sa Covid šifrom...
+    v1_legacy_inform_detail_box_title: Zaustavljanje lanca širenja infekcije
+    v1_legacy_inform_detail_box_button: Unos Covid šifre
+    v1_legacy_inform_detail_box_text: Unosom Covid šifre obaveštavate aplikaciju da ste testirani pozitivno na virus korona.
+    v1_legacy_inform_detail_faq1_title: Šta je Covid šifra?
+    v1_legacy_inform_detail_faq1_text: Osobe pozitivno testirane na korona virus (PCR test ili antigen (brzi test) dobijaju kovid šifru.\n\nTime se obezbeđuje da samo potvrđeni slučajevi budu prijavljeni preko aplikacije.
+    v1_legacy_inform_detail_faq2_title: Šta se šalje?
+    v1_legacy_inform_detail_faq2_text: Šalju se samo privatni identifikacioni ključevi iz vaše aplikacije, a ne šalju se lični podaci.\n\nTime drugi korisnici aplikacije SwissCovid mogu da saznaju da postoji mogućnost infekcije.
+    v1_legacy_inform_detail_faq3_text: Iako se lični podaci koji se odnose na vas ne šalju, možda se neko seća svog kontakta sa vama na osnovu datuma.
+    v1_legacy_inform_detail_faq3_title: Da li ostajem anoniman?
+    v1_legacy_infoline_coronavirus_number: +41 58 387 77 80
+    v1_legacy_hearing_impaired_info: Da li ste bez sluha ili imate smetnju sluha i ne možete nazvati Infoline Coronavirus?\n\nOnda pošaljite e-mail na covid-support@medgate.ch
+    v1_legacy_inform_detail_infobox1_text: Pozitivno ste testirani (PCR test ili antigen brzi test) i ni posle 4 sata niste dobili kovid šifru?\nU tom slučaju kontaktirajte Infoline Coronavirus:
+    v1_legacy_inform_detail_infobox1_title: Još niste dobili Covid šifru?

--- a/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_it.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_it.properties
@@ -1,0 +1,15 @@
+it:
+    v1_legacy_inform_detail_box_subtitle: Con il codice Covid...
+    v1_legacy_inform_detail_box_title: Fermare le catene di infezione
+    v1_legacy_inform_detail_box_button: Immetti il codice Covid
+    v1_legacy_inform_detail_box_text: Immettendo il codice Covid, comunichi all'app che sei risultato positivo al test del nuovo coronavirus.
+    v1_legacy_inform_detail_faq1_title: Cos'è un codice Covid?
+    v1_legacy_inform_detail_faq1_text: Le persone che sono risultate positive al test del coronavirus (PCR o antigenico rapido) ricevono un codice Covid.\n\nIn questo modo si garantisce che l'app segnali soltanto i casi confermati.
+    v1_legacy_inform_detail_faq2_title: Che cosa viene inviato?
+    v1_legacy_inform_detail_faq2_text: Vengono inviate soltanto le chiavi private della tua app, non i tuoi dati personali.\n\nIn questo modo gli altri utenti dell'app SwissCovid vengono a sapere che vi è la possibilità di un contagio.
+    v1_legacy_inform_detail_faq3_text: Anche se non vengono inviati dati personali, è possibile che qualcuno possa ricordarsi dell'incontro sulla base della data in cui è avvenuto.
+    v1_legacy_inform_detail_faq3_title: Resto anonimo?
+    v1_legacy_infoline_coronavirus_number: +41 58 387 77 80
+    v1_legacy_hearing_impaired_info: Siete sordi o audiolesi e non potete chiamare l'Infoline Coronavirus?\n\nScrivete un'e-mail all'indirizzo: covid-support@medgate.ch
+    v1_legacy_inform_detail_infobox1_text: Sei risultato positivo al test (PCR o antigenico rapido) e dopo quattro ore non hai ancora ricevuto un codice Covid?\nContatta la Infoline coronavirus:
+    v1_legacy_inform_detail_infobox1_title: Non hai ancora un codice Covid?

--- a/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_pt.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_pt.properties
@@ -1,0 +1,15 @@
+pt:
+    v1_legacy_inform_detail_box_subtitle: Com o código COVID...
+    v1_legacy_inform_detail_box_title: Travar as cadeias de transmissão
+    v1_legacy_inform_detail_box_button: Inserir código COVID
+    v1_legacy_inform_detail_box_text: Ao introduzir o código COVID, notifica a app de que testou positivo para o novo coronavírus.
+    v1_legacy_inform_detail_faq1_title: O que é um código COVID?
+    v1_legacy_inform_detail_faq1_text: Pessoas com teste de coronavírus positivo (teste PCR ou teste rápido de antigénio) recebem um código Covid.\n\nIsso assegura que só casos confirmados sejam comunicados através do aplicativo.
+    v1_legacy_inform_detail_faq2_title: Que dados são enviados?
+    v1_legacy_inform_detail_faq2_text: Só são enviadas as chaves privadas do seu app e nunca dados pessoais.\n\nDesta forma, outros utilizadores do app SwissCovid ficam a saber que existe a possibilidade de um contágio.
+    v1_legacy_inform_detail_faq3_text: Embora não sejam enviados dados pessoais seus, é possível que alguém se recorde de um contacto consigo pela data.
+    v1_legacy_inform_detail_faq3_title: Permaneço anónimo?
+    v1_legacy_infoline_coronavirus_number: +41 58 387 77 80
+    v1_legacy_hearing_impaired_info: Sofre de surdez ou de insuficiência auditiva e não pode ligar para a linha informativa do coronavírus?\n\nNesse caso, envie um e-mail para covid-support@medgate.ch
+    v1_legacy_inform_detail_infobox1_text: Foi testado positivo (teste PCR ou teste rápido de antigénio) e ainda não recebeu um código Covid depois de 4 hs?\nContacte a linha de informação coronavírus:
+    v1_legacy_inform_detail_infobox1_title: Ainda não recebeu um código COVID?

--- a/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_rm.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_rm.properties
@@ -1,0 +1,15 @@
+rm: 
+    v1_legacy_inform_detail_box_subtitle: Cun il code covid...
+    v1_legacy_inform_detail_box_title: Franar chadainas d'infecziun
+    v1_legacy_inform_detail_box_button: Endatar il code covid
+    v1_legacy_inform_detail_box_text: Cun endatar il code covid communitgais Vus a l'app che Vus essas testada/testà en moda positiva sin il nov coronavirus
+    v1_legacy_inform_detail_faq1_title: Tge è in code covid?
+    v1_legacy_inform_detail_faq1_text: Persunas cun in test positiv sin il coronavirus (test da PCR u test svelt d'antigens) retschaivan in code covid.\n\nUschia vegn garantì ch'i vegnian annunziads sur l'app mo ils cas confermads.
+    v1_legacy_inform_detail_faq2_title: Tge vegn tramess?
+    v1_legacy_inform_detail_faq2_text: I vegnan tramessas mo las clavs privatas da Vossa app, naginas datas persunalas.\n\nUschia vegnan autras utilisadras ed auters utilisaders da l'app SwissCovid a savair ch'ina infecziun è pussaivla.
+    v1_legacy_inform_detail_faq3_text: Cumbain ch'i na vegnan tramessas naginas datas davart Vossa persuna, èsi pussaivel ch'insatgi sa regorda da l'inscunter a maun da la data.
+    v1_legacy_inform_detail_faq3_title: Rest jau anonima/anonim?
+    v1_legacy_infoline_coronavirus_number: +41 58 387 77 80
+    v1_legacy_hearing_impaired_info: Essas Vus senza udida u avais Vus in impediment d'udida e na pudais betg telefonar a la Infoline coronavirus?\n\nAlura tramettai in e-mail a covid-support@medgate.ch
+    v1_legacy_inform_detail_infobox1_text: Vus avais in test positiv (test da PCR u test svelt d'antigens) e n'avais suenter 4 uras anc betg retschavì in code covid?\nAlura contactai la Infoline coronavirus:
+    v1_legacy_inform_detail_infobox1_title: Anc nagin code covid?

--- a/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_sq.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_sq.properties
@@ -1,0 +1,15 @@
+sq:
+    v1_legacy_inform_detail_box_subtitle: Me kodin Covid...
+    v1_legacy_inform_detail_box_title: Ndalo zinxhirin e infeksionit
+    v1_legacy_inform_detail_box_button: Fut kodin e Covid
+    v1_legacy_inform_detail_box_text: Me futjen e kodit të Covid ju njoftoni aplikacionin që jeni testuar pozitivë me koronavirusin e ri.
+    v1_legacy_inform_detail_faq1_title: Çfarë është një kod Covid?
+    v1_legacy_inform_detail_faq1_text: Njerëzit që kanë rezultuar pozitivë për koronavirusin (test PCR ose test i shpejtë i antigjenit) marrin një kod Covid.\n\nKjo siguron se vetëm rastet e konfirmuara raportohen përmes aplikacionit.
+    v1_legacy_inform_detail_faq2_title: Çfarë dërgohet?
+    v1_legacy_inform_detail_faq2_text: Dërgohen vetëm kodet e identifikimit të aplikacionit tuaj, asnjë e dhënë personale.\n\nNë këtë mënyrë mësoni përdoruesit e tjerë të alikacionit SwissCovid, të cilët mundësisht janë infektuar.
+    v1_legacy_inform_detail_faq3_text: Edhe pse nuk dërgohet asnjë e dhënë personale, mund të ndodhë që dikush mund të kujtohet për kontaktin me anë të datës.
+    v1_legacy_inform_detail_faq3_title: A mbetem unë anonim?
+    v1_legacy_infoline_coronavirus_number: +41 58 387 77 80
+    v1_legacy_hearing_impaired_info: A jeni i shurdhër ose keni probleme dëgjimi dhe nuk mund të telefononi linjën telefonike për koronavirusin Infoline Coronavirus?\n\nAtëherë na dërgoni një email te covid-support@medgate.ch
+    v1_legacy_inform_detail_infobox1_text: A keni testuar pozitiv (nga test PCR ose test i shpejtë antigjeni) dhe nuk keni marrë një kod Covid pas 4 orësh? \nAtëherë kontaktoni qendrën telefonike të koronavirusit:
+    v1_legacy_inform_detail_infobox1_title: Nuk keni marrë ende asnjë kod Covid?

--- a/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_sr.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_sr.properties
@@ -1,0 +1,15 @@
+sr:
+    v1_legacy_inform_detail_box_subtitle: Sa Covid šifrom...
+    v1_legacy_inform_detail_box_title: Zaustavljanje lanca širenja infekcije
+    v1_legacy_inform_detail_box_button: Unos Covid šifre
+    v1_legacy_inform_detail_box_text: Unosom Covid šifre obaveštavate aplikaciju da ste testirani pozitivno na virus korona.
+    v1_legacy_inform_detail_faq1_title: Šta je Covid šifra?
+    v1_legacy_inform_detail_faq1_text: Osobe pozitivno testirane na korona virus (PCR test ili antigen (brzi test) dobijaju kovid šifru.\n\nTime se obezbeđuje da samo potvrđeni slučajevi budu prijavljeni preko aplikacije.
+    v1_legacy_inform_detail_faq2_title: Šta se šalje?
+    v1_legacy_inform_detail_faq2_text: Šalju se samo privatni identifikacioni ključevi iz vaše aplikacije, a ne šalju se lični podaci.\n\nTime drugi korisnici aplikacije SwissCovid mogu da saznaju da postoji mogućnost infekcije.
+    v1_legacy_inform_detail_faq3_text: Iako se lični podaci koji se odnose na vas ne šalju, možda se neko seća svog kontakta sa vama na osnovu datuma.
+    v1_legacy_inform_detail_faq3_title: Da li ostajem anoniman?
+    v1_legacy_infoline_coronavirus_number: +41 58 387 77 80
+    v1_legacy_hearing_impaired_info: Da li ste bez sluha ili imate smetnju sluha i ne možete nazvati Infoline Coronavirus?\n\nOnda pošaljite e-mail na covid-support@medgate.ch
+    v1_legacy_inform_detail_infobox1_text: Pozitivno ste testirani (PCR test ili antigen brzi test) i ni posle 4 sata niste dobili kovid šifru?\nU tom slučaju kontaktirajte Infoline Coronavirus:
+    v1_legacy_inform_detail_infobox1_title: Još niste dobili Covid šifru?

--- a/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_ti.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_ti.properties
@@ -1,0 +1,15 @@
+ti:
+    v1_legacy_inform_detail_box_subtitle: ብኮቪድኮድ
+    v1_legacy_inform_detail_box_title: ሰንሰለት ለበዳ ሕማም ምቁራጽ
+    v1_legacy_inform_detail_box_button: ኮቪድኮድ ኣእትው
+    v1_legacy_inform_detail_box_text: ኮቪድኮድ ብምእታውኩም ነቲ ኣፕ  ውጽኢት መርመራኹም ፖዚቲቭ ንሓድሽ ኮሮናቫይረስ ከምዝኾነ ትሕብሩ።   
+    v1_legacy_inform_detail_faq1_title: ኮቪድኮድ እንታይ እዩ፧
+    v1_legacy_inform_detail_faq1_text: ሰባት ኮሮናቫይረስ ከምዘለዎም ምስዝረጋግጽ / ፖዚቲቭ ምስኮኑ (ናይ PCR መርመራ ወይ ቅልጡፍ መርመራ ጸረ-ፈርዒ) ሓደ ኮቪድ-ኮድ ክወሃቡ እዮም።\n\nሽዑ ጥራይ ዝተረጋገጹ ጉዳያት በቲ ኤፕ ክሕበሩ ከምዝኾኑ ተረጋጊጹ።
+    v1_legacy_inform_detail_faq2_title: እንታይ እዩ ዝስደድ፧ 
+    v1_legacy_inform_detail_faq2_text: ውልቃዊ ሓበሬታ ዘይኮነ፣ ጥራይ እቶም ግላውያን መፋትሕ እዮም ዝስደዱ።\n  \nብኸምዚ መንገዲ ካልኦት ተጠቀምቲ ስዊስኮቪድ ተኽእሎ መልከፍቲ ሕማም ከምዘሎ ይፈልጡ።
+    v1_legacy_inform_detail_faq3_text: ዋላኳ  ዝኾነ ሓበሬታ ብዛዕባኹም እንተዘይተሰደደ ዝኾነ ሰብ በቲ ዕለት ጌሩ ምርኻብኩም ክዝክሮ ይኽእል እዩ። 
+    v1_legacy_inform_detail_faq3_title: ስቱር ድዩ፧
+    v1_legacy_infoline_coronavirus_number: +41 58 387 77 80
+    v1_legacy_hearing_impaired_info: ክትሰምዑ ኣይትኽእሉን ወይ ናይ ምስማዕ ስንክልና ስለዘለና ነቲ ሓበሬታ ስልኪ ኮሮናቫይረስ ክትድውሉ ኣይትኽእሉን፧\n\nሽዑ ኢመይል ናብ covid-support@medgate.ch ስደዱ ኢኹም
+    v1_legacy_inform_detail_infobox1_text: ፖዚቲቭ ተመርሚርኩም (ናይ PCR መርመራ ወይ ቅልጡፍ መርመራ ጸረ-ፈርዒ) ከምኡ'ውን ድሕሪ 4 ሰዓት ገና ናይ ኮቪድ ኮድ ኣይተወሃብኩምን፧ ሽዑ እቲ ኢንፎላይን ኮሮናቫይረስ ርኸቡ ኢኹም፥
+    v1_legacy_inform_detail_infobox1_title: ናይ ኮቪድ ኮድ ገና የብልኩምን፧

--- a/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_tr.properties
+++ b/dpppt-config-backend/src/main/resources/i18n/messages_v1_legacy_tr.properties
@@ -1,0 +1,15 @@
+tr:
+    v1_legacy_inform_detail_box_subtitle: Kovid kodu ile...
+    v1_legacy_inform_detail_box_title: Enfeksiyon zincirini kır
+    v1_legacy_inform_detail_box_button: Kovid kodu gir
+    v1_legacy_inform_detail_box_text: Kovid kodunu girerek, uygulamaya Korona virüsüne ilişkin pozitif test edildiğinizi bildirirsiniz.
+    v1_legacy_inform_detail_faq1_title: Bir Kovid kodu nedir?
+    v1_legacy_inform_detail_faq1_text: Koronavirüs için testi pozitif çıkan kişiler (PCR testi veya hızlı antijen testi) bir Covid kodu alır.\n\nBöylece uygulama üzerinden yalnızca onaylı vakaların bildirilmesi sağlanır.
+    v1_legacy_inform_detail_faq2_title: Neler iletilir?
+    v1_legacy_inform_detail_faq2_text: Şahsi bilgileriniz değil, uygulamanızın yalnızca özel kodları iletilir. \nBu şekilde diğer SwissCovid uygulaması kullanıcıları yalnızca bir bulaşma riski olabileceğini öğenir.
+    v1_legacy_inform_detail_faq3_text: Kişisel bilgileriniz iletilmese dahi, bazı kişiler tarihler temelinde sizinle olan teması hatırlayabilirler.
+    v1_legacy_inform_detail_faq3_title: Bilgilerim anonim mi?
+    v1_legacy_infoline_coronavirus_number: +41 58 387 77 80
+    v1_legacy_hearing_impaired_info: İşitmiyor veya işitme özürlü müsünüz ve Koronavirüs bilgi hattını arayamıyor musunuz?\n\nO halde covid-support@medgate.ch adresine bir e-posta gönderiniz
+    v1_legacy_inform_detail_infobox1_text: Testiniz pozitif çıktı (PCR testi veya hızlı antijen testi) ve 4 saat sonra halen bir Covid kodu almadınız mı?\nO halde koronavirüz danışma hattıyla iletişim kurun:
+    v1_legacy_inform_detail_infobox1_title: Covid kodunu henüz almadınız mı?


### PR DESCRIPTION
This PR makes sure, that v1.x versions of the SwissCovid app still get meaningful texts in the absence of the checkin feature.

